### PR TITLE
chore: change nodejs engine requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "typescript": "^5.1.6"
   },
   "engines": {
-    "node": "16.x"
+    "node": ">=16.0.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
it was to strict: nodejs 16 only. Loose strictness for everything up 16