### PR TITLE
fix: no-unlocalized properly utilize ignoreFunction option

### DIFF
--- a/src/rules/no-unlocalized-strings.ts
+++ b/src/rules/no-unlocalized-strings.ts
@@ -107,7 +107,7 @@ const rule: RuleModule<string, Option[]> = {
           if (callee.name === 'require') {
             return true
           }
-          return calleeWhitelists.complex.indexOf(callee.name) !== -1
+          return calleeWhitelists.simple.indexOf(callee.name) !== -1
         }
         default:
           return false

--- a/tests/src/rules/no-unlocalized-strings.test.ts
+++ b/tests/src/rules/no-unlocalized-strings.test.ts
@@ -145,6 +145,10 @@ ruleTester.run<string, Option[]>('no-unlocalized-strings', rule, {
       code: 'new Error("hello")',
       options: [{ ignoreFunction: ['Error'] }],
     },
+    {
+      code: 'hello("Hello")',
+      options: [{ ignoreFunction: ['hello'] }],
+    },
     { code: '<div>&nbsp; </div>' },
     { code: "plural('hello')" },
     { code: "select('hello')" },


### PR DESCRIPTION
`ignoreFunction` was not properly working as configured