### PR TITLE
feat(no-unlocalized-strings): add ignoreProperty option

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,21 @@ Examples of correct code for the `{ "ignoreAttribute": ["style"] }` option:
 const element = <div style={{ margin: '1rem 2rem' }} />
 ```
 
+By default, the following attributes are ignored: `className`, `styleName`, `type`, `id`, `width`, `height`
+
+#### ignoreProperty
+
+The `ignoreProperty` option specifies property names not to check.
+
+Examples of correct code for the `{ "ignoreProperty": ["text"] }` option:
+
+```jsx
+/*eslint lingui/no-unlocalized-strings: ["error", { "ignoreProperty": ["text"] }]*/
+const test = { text: 'This is ignored' }
+```
+
+By default, the following properties are ignored: `className`, `styleName`, `type`, `id`, `width`, `height`
+
 ## t-call-in-function
 
 Check that `t` calls are inside `function`. They should not be at the module level otherwise they will not react to language switching.

--- a/src/rules/no-unlocalized-strings.ts
+++ b/src/rules/no-unlocalized-strings.ts
@@ -18,6 +18,7 @@ export type Option = {
   ignore?: string[]
   ignoreFunction?: string[]
   ignoreAttribute?: string[]
+  ignoreProperty?: string[]
 }
 const rule: RuleModule<string, Option[]> = {
   meta: {
@@ -45,6 +46,12 @@ const rule: RuleModule<string, Option[]> = {
             },
           },
           ignoreAttribute: {
+            type: 'array',
+            items: {
+              type: 'string',
+            },
+          },
+          ignoreProperty: {
             type: 'array',
             items: {
               type: 'string',
@@ -129,9 +136,18 @@ const rule: RuleModule<string, Option[]> = {
 
       ...ignoredAttributes,
     ]
-    function isValidAttrName(name: string) {
-      return userJSXAttrs.includes(name)
-    }
+
+    const ignoredProperties = (option && option.ignoreProperty) || []
+    const userProperties = [
+      'className',
+      'styleName',
+      'type',
+      'id',
+      'width',
+      'height',
+
+      ...ignoredProperties,
+    ]
 
     //----------------------------------------------------------------------
     // Public
@@ -170,7 +186,7 @@ const rule: RuleModule<string, Option[]> = {
       const parent = getNearestAncestor<TSESTree.JSXAttribute>(node, 'JSXAttribute')
       const attrName = getAttrName(parent?.name?.name)
       // allow <MyComponent className="active" />
-      if (isValidAttrName(getAttrName(parent?.name?.name))) {
+      if (userJSXAttrs.includes(getAttrName(parent?.name?.name))) {
         visited.add(node)
         return
       }
@@ -199,7 +215,7 @@ const rule: RuleModule<string, Option[]> = {
         // dont care whether if this is computed or not
         if (
           parent?.key?.type === TSESTree.AST_NODE_TYPES.Identifier &&
-          isUpperCase(parent?.key?.name)
+          (isUpperCase(parent?.key?.name) || userProperties.includes(parent?.key?.name))
         ) {
           visited.add(node)
         }

--- a/tests/src/rules/no-unlocalized-strings.test.ts
+++ b/tests/src/rules/no-unlocalized-strings.test.ts
@@ -8,7 +8,7 @@ import { RuleTester } from '@typescript-eslint/utils/dist/ts-eslint/RuleTester'
 const message = 'disallow literal string'
 const errors = [{ messageId: 'default', data: { message } }] // default errors
 
-var ruleTester = new RuleTester({
+const ruleTester = new RuleTester({
   parser: TYPESCRIPT_ESLINT,
   parserOptions: {
     sourceType: 'module',
@@ -172,6 +172,11 @@ ruleTester.run<string, Option[]>('no-unlocalized-strings', rule, {
       code:
         "const Wrapper = styled.a` cursor: pointer; ${(props) => props.isVisible && 'visibility: visible;'}`",
     },
+    { code: `const test = { id: 'This is not localized' }` },
+    {
+      code: `const test = { text: 'This is not localized' }`,
+      options: [{ ignoreProperty: ['text'] }],
+    },
   ],
 
   invalid: [
@@ -221,6 +226,7 @@ ruleTester.run<string, Option[]>('no-unlocalized-strings', rule, {
     { code: '<DIV foo="Bar" />', errors },
     { code: '<img src="./image.png" alt="some image" />', errors },
     { code: '<button aria-label="Close" type="button" />', errors },
+    { code: `const test = { text: 'This is not localized' }`, errors },
     {
       code: `function getQueryPlaceholder(compact: boolean | undefined) {
         return compact || mobileMediaQuery.matches
@@ -348,7 +354,7 @@ tsTester.run('no-unlocalized-strings', rule, {
       code: "function Button({ t= 'Name'  }: {t: 1 |  'Abs'}){} ",
       errors,
     },
-    { code: "var a: {type: string} = {type: 'Bold'}", errors },
+    { code: "var a: {text: string} = {text: 'Bold'}", errors },
     {
       code: `function getQueryPlaceholder(compact: boolean | undefined) {
         return compact || mobileMediaQuery.matches


### PR DESCRIPTION
Adds `ignoreProperty` option to `no-unlocalized-strings` rule as discussed here https://github.com/lingui/eslint-plugin/discussions/17