### PR TITLE
fix(no-unlocalized-strings): Enhanced `no-unlocalized` Rule for advanced syntax support

### DIFF
--- a/src/rules/no-unlocalized-strings.ts
+++ b/src/rules/no-unlocalized-strings.ts
@@ -94,7 +94,9 @@ const rule: RuleModule<string, Option[]> = {
       return whitelists.some((item) => item.test(str))
     }
 
-    function isValidFunctionCall({ callee }: TSESTree.CallExpression | TSESTree.NewExpression) {
+    function isValidFunctionCall({
+      callee,
+    }: TSESTree.CallExpression | TSESTree.NewExpression): boolean {
       switch (callee.type) {
         case TSESTree.AST_NODE_TYPES.MemberExpression: {
           if (
@@ -115,6 +117,13 @@ const rule: RuleModule<string, Option[]> = {
             return true
           }
           return calleeWhitelists.simple.indexOf(callee.name) !== -1
+        }
+        case TSESTree.AST_NODE_TYPES.CallExpression: {
+          return (
+            (callee.callee.type === TSESTree.AST_NODE_TYPES.MemberExpression ||
+              callee.callee.type === TSESTree.AST_NODE_TYPES.Identifier) &&
+            isValidFunctionCall(callee)
+          )
         }
         default:
           return false

--- a/tests/src/rules/no-unlocalized-strings.test.ts
+++ b/tests/src/rules/no-unlocalized-strings.test.ts
@@ -22,6 +22,11 @@ ruleTester.run<string, Option[]>('no-unlocalized-strings', rule, {
     {
       code: 'i18n._(t`Hello ${nice}`)',
     },
+    { code: 't(i18n)({ message: `Hello ${name}` })' },
+    {
+      code: 'custom.wrapper()({message: "Hello!"})',
+      options: [{ ignoreFunction: ['custom.wrapper'] }],
+    },
     { code: 'name === `Hello brat` || name === `Nice have`' },
     { code: 'switch(a){ case `a`: break; default: break;}' },
     { code: 'a.indexOf(`ios`)' },


### PR DESCRIPTION
**Changes**:

-   Support added for the following syntax patterns:
    - ```javascript
       t(i18n)({ message: `Hello ${name}` })
       ```
    - ```javascript
       custom.wrapper()({message: "Hello!"})
       ```

**Problem**: Previously, the `isValidFunctionCall` helper did not fully process function calls involving `callee` with a `MemberExpression` type.

**Solution**: The update ensures that `ignoreFunction` within `CallExpression` is properly utilized.