### PR TITLE
fix(no-unlocalized-strings): Correct Parent Node Handling for TS Enums

### DIFF
--- a/src/rules/no-unlocalized-strings.ts
+++ b/src/rules/no-unlocalized-strings.ts
@@ -348,7 +348,7 @@ const rule: RuleModule<string, Option[]> = {
         onClassProperty(node)
       },
 
-      'TSEnumDeclaration > Literal'(node: TSESTree.Literal) {
+      'TSEnumMember > Literal'(node: TSESTree.Literal) {
         visited.add(node)
       },
 
@@ -425,7 +425,7 @@ const rule: RuleModule<string, Option[]> = {
       'ClassProperty > TemplateLiteral'(node: TSESTree.TemplateLiteral) {
         onClassProperty(node)
       },
-      'TSEnumDeclaration > TemplateLiteral'(node: TSESTree.TemplateLiteral) {
+      'TSEnumMember > TemplateLiteral'(node: TSESTree.TemplateLiteral) {
         visited.add(node)
       },
       'VariableDeclarator > TemplateLiteral'(node: TSESTree.TemplateLiteral) {

--- a/tests/src/rules/no-unlocalized-strings.test.ts
+++ b/tests/src/rules/no-unlocalized-strings.test.ts
@@ -333,6 +333,11 @@ tsTester.run('no-unlocalized-strings', rule, {
         Address = 'Address'
       }`,
     },
+    {
+      code: `enum StepType {
+        Address = \`Address\`
+      }`,
+    },
   ],
   invalid: [
     { code: `var a = 'Hello guys'`, errors },


### PR DESCRIPTION

**Changes**:

-   Updated parent nodes for processing `Literal` and `TemplateLiteral` in the context of TypeScript enums. The modifications are as follows:
    ```diff
    -'TSEnumDeclaration > Literal'(node: TSESTree.Literal) {
    +'TSEnumMember > Literal'(node: TSESTree.Literal) {
     
    -'TSEnumDeclaration > TemplateLiteral'(node: TSESTree.TemplateLiteral) {
    +'TSEnumMember > TemplateLiteral'(node: TSESTree.TemplateLiteral) {
    ```

**Issue**: The problem was evident when `parserServices.program` was empty, leading to incorrect parent node referencing for `Literal` and `TemplateLiteral` within TypeScript enums, affecting the rule's effectiveness.

**Resolution**: By changing the parent node references from `TSEnumDeclaration` to `TSEnumMember` for both `Literal` and `TemplateLiteral`, this fix ensures the correct processing of these nodes in TypeScript enum scenarios, even with an empty `parserServices.program`.

**Note**: Previously added tests for this rule were passing because the `typeChecker` was used for additional verification of `Literal`. However, this approach also led to slower rule execution.