### PR TITLE
feat: allow calls to plural function in no-expression-in-message

### DIFF
--- a/src/rules/no-expression-in-message.ts
+++ b/src/rules/no-expression-in-message.ts
@@ -31,8 +31,13 @@ const rule: RuleModule<string, readonly unknown[]> = {
     return {
       'TemplateLiteral:exit'(node: TSESTree.TemplateLiteral) {
         const noneIdentifierExpressions = node.expressions
-          ? node.expressions.filter((expression: { type: string }) => {
-              return expression.type !== TSESTree.AST_NODE_TYPES.Identifier
+          ? node.expressions.filter((expression) => {
+              const isIdentifier = expression.type === TSESTree.AST_NODE_TYPES.Identifier
+              const isCallToPluralFunction =
+                expression.type === TSESTree.AST_NODE_TYPES.CallExpression &&
+                expression.callee.type === TSESTree.AST_NODE_TYPES.Identifier &&
+                expression.callee.name === 'plural'
+              return !isIdentifier && !isCallToPluralFunction
             })
           : []
 

--- a/tests/src/rules/no-expression-in-message.test.ts
+++ b/tests/src/rules/no-expression-in-message.test.ts
@@ -40,6 +40,9 @@ const tests = {
     {
       code: 't`Hello ${hello}`',
     },
+    {
+      code: 't`Hello ${plural()}`',
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
Lingui allows to embed the `plural` macro inside the `t` macro, creating a message that includes the plural, similar to [nested plurals](https://lingui.dev/ref/macro#plural). 

For an example consider the following macro call:

```javascript
import { plural, t } from '@lingui/macro';
const message = t`Count: ${plural(count, {
  one: '# book',
  other: '# books',
})}`;
```

It gets represented in the message catalog as a single message: `Count: {count, plural, one {# book} other {# books}}`.

However the `no-expression-in-message` rule currently forbids this pattern since the expression in the template string is not an identifier. This PR changes that behavior, allowing calls to the `plural` function to occur inside the `t` macro.