### PR TITLE
fix(no-unlocalized-strings): `ignoreProperty` support MemberExpression assignments

### DIFF
--- a/src/rules/no-unlocalized-strings.ts
+++ b/src/rules/no-unlocalized-strings.ts
@@ -154,7 +154,7 @@ const rule: RuleModule<string, Option[]> = {
       'id',
       'width',
       'height',
-
+      'displayName',
       ...ignoredProperties,
     ]
 
@@ -373,6 +373,17 @@ const rule: RuleModule<string, Option[]> = {
       },
       'Property > Literal'(node: TSESTree.Literal) {
         onProperty(node)
+      },
+      "AssignmentExpression[left.type='MemberExpression'] > Literal"(node: TSESTree.Literal) {
+        const assignmentExp = node.parent as TSESTree.AssignmentExpression
+        const memberExp = assignmentExp.left as TSESTree.MemberExpression
+        if (
+          !memberExp.computed &&
+          memberExp.property.type === TSESTree.AST_NODE_TYPES.Identifier &&
+          userProperties.includes(memberExp.property.name)
+        ) {
+          visited.add(node)
+        }
       },
       'BinaryExpression > Literal'(node: TSESTree.Literal) {
         onBinaryExpression(node)

--- a/tests/src/rules/no-unlocalized-strings.test.ts
+++ b/tests/src/rules/no-unlocalized-strings.test.ts
@@ -185,7 +185,6 @@ ruleTester.run<string, Option[]>('no-unlocalized-strings', rule, {
   ],
 
   invalid: [
-    { code: "ItemRenderer.displayName = 'ItemRenderer'", errors },
     { code: "<Plural value='Hello' one='2' notOther='3' /> ", errors },
     { code: "<Select value='Hello' one='2' notOther='3' /> ", errors },
     { code: "<Plural notValue='Hello' one='2' other='3' /> ", errors },
@@ -342,6 +341,14 @@ tsTester.run('no-unlocalized-strings', rule, {
       code: `enum StepType {
         Address = \`Address\`
       }`,
+    },
+    {
+      code: `MyComponent.myIgnoredProperty = 'MyComponent';`,
+      options: [{ ignoreProperty: ['myIgnoredProperty'] }],
+    },
+    {
+      // displayName is ignored by default
+      code: `MyComponent.displayName = 'MyComponent';`,
     },
   ],
   invalid: [


### PR DESCRIPTION
Fixing https://github.com/lingui/eslint-plugin/issues/37

i've found this one is more annoying that the rest, because 

```ts
MyComponent.displayName = "MyComponent"
```

Is quite popular pattern in react ecosystem. 

Related https://github.com/lingui/eslint-plugin/issues/50

What was changed: 

- `ignoreProperty` now applies to the `MyComponent.displayName = "MyComponent"`
- `displayName` is ignored by default