### PR TITLE
fix(no-expression-in-message): add select and selectOrdinal to exclusion

### DIFF
--- a/src/rules/no-expression-in-message.ts
+++ b/src/rules/no-expression-in-message.ts
@@ -26,16 +26,18 @@ export const rule = createRule({
   defaultOptions: [],
 
   create: function (context) {
+    const linguiMacroFunctionNames = ['plural', 'select', 'selectOrdinal']
+
     return {
       'TemplateLiteral:exit'(node: TSESTree.TemplateLiteral) {
         const noneIdentifierExpressions = node.expressions
           ? node.expressions.filter((expression) => {
               const isIdentifier = expression.type === TSESTree.AST_NODE_TYPES.Identifier
-              const isCallToPluralFunction =
+              const isCallToLinguiMacro =
                 expression.type === TSESTree.AST_NODE_TYPES.CallExpression &&
                 expression.callee.type === TSESTree.AST_NODE_TYPES.Identifier &&
-                expression.callee.name === 'plural'
-              return !isIdentifier && !isCallToPluralFunction
+                linguiMacroFunctionNames.includes(expression.callee.name)
+              return !isIdentifier && !isCallToLinguiMacro
             })
           : []
 

--- a/tests/src/rules/no-expression-in-message.test.ts
+++ b/tests/src/rules/no-expression-in-message.test.ts
@@ -31,6 +31,12 @@ ruleTester.run(name, rule, {
     {
       code: 't`Hello ${plural()}`',
     },
+    {
+      code: 't`Hello ${select()}`',
+    },
+    {
+      code: 't`Hello ${selectOrdinal()}`',
+    },
   ],
   invalid: [
     {


### PR DESCRIPTION
This extends the support for calling a the `plural` macro in a `t` macro introduced in #48 to also apply to `select` and `selectOrdinal`.