### PR TITLE
fix(no-unlocalized-strings): ignore Literals in computed MemberExpression

### DIFF
--- a/src/rules/no-unlocalized-strings.ts
+++ b/src/rules/no-unlocalized-strings.ts
@@ -368,6 +368,10 @@ export const rule = createRule<Option[], string>({
       'Property > Literal'(node: TSESTree.Literal) {
         onProperty(node)
       },
+      'MemberExpression[computed=true] > Literal'(node: TSESTree.Literal) {
+        // obj["key with space"]
+        visited.add(node)
+      },
       "AssignmentExpression[left.type='MemberExpression'] > Literal"(node: TSESTree.Literal) {
         const assignmentExp = node.parent as TSESTree.AssignmentExpression
         const memberExp = assignmentExp.left as TSESTree.MemberExpression
@@ -452,6 +456,10 @@ export const rule = createRule<Option[], string>({
         ) {
           visited.add(node)
         }
+      },
+      'MemberExpression[computed=true] > TemplateLiteral'(node: TSESTree.TemplateLiteral) {
+        // obj[`key with space`]
+        visited.add(node)
       },
       'Property > TemplateLiteral'(node: TSESTree.TemplateLiteral) {
         onProperty(node)

--- a/tests/src/rules/no-unlocalized-strings.test.ts
+++ b/tests/src/rules/no-unlocalized-strings.test.ts
@@ -180,6 +180,8 @@ ruleTester.run<string, Option[]>(name, rule, {
       code: `const test = { text: 'This is not localized' }`,
       options: [{ ignoreProperty: ['text'] }],
     },
+    { code: `obj["key with space"] = 5` },
+    { code: `obj[\`key with space\`] = 5` },
   ],
 
   invalid: [


### PR DESCRIPTION
Completely ignore from checking literals in computed member expressions, eq:

Partially fixes: https://github.com/lingui/eslint-plugin/issues/38
Tracking issue #50 

```js
// valid
obj["key with space"] 
obj[`key with space`]
```