### PR TITLE
feat(no-unlocalized-strings): add ignoreMethodsOnTypes option

### DIFF
--- a/docs/rules/no-unlocalized-strings.md
+++ b/docs/rules/no-unlocalized-strings.md
@@ -9,7 +9,7 @@ Check that code doesn't contain strings/templates/jsxText what should be wrapped
 
 ### useTsTypes
 
-Use additional Typescript type information. Requires [typed linting](https://typescript-eslint.io/getting-started/typed-linting/) to be setup.
+Use additional TypeScript type information. Requires [typed linting](https://typescript-eslint.io/getting-started/typed-linting/) to be setup.
 
 Will automatically exclude some built-in methods such as `Map` and `Set`, and also cases where a string literal is used as a TypeScript constant:
 
@@ -95,3 +95,6 @@ interface Foo {
 const foo: Foo
 
 foo.get('string with a spaces')
+```
+
+The following methods are ignored by default: `Map.get`, `Map.has`, `Set.has`.

--- a/docs/rules/no-unlocalized-strings.md
+++ b/docs/rules/no-unlocalized-strings.md
@@ -11,8 +11,7 @@ Check that code doesn't contain strings/templates/jsxText what should be wrapped
 
 Use additional Typescript type information. Requires [typed linting](https://typescript-eslint.io/getting-started/typed-linting/) to be setup.
 
-Will automatically exclude some built-in methods such as `Map` and `Set`
-and also cases where string literal is used as typescript constant.
+Will automatically exclude some built-in methods such as `Map` and `Set`, and also cases where a string literal is used as a TypeScript constant:
 
 ```ts
 const a: 'abc' = 'abc'
@@ -80,11 +79,11 @@ By default, the following properties are ignored: `className`, `styleName`, `typ
 
 ### ignoreMethodsOnTypes
 
-Leverage power of Typescript to exclude methods defined on specific types.
+Leverage the power of TypeScript to exclude methods defined on specific types.
 
-Note: You need to set `useTsTypes: true` to use this
+Note: You must set `useTsTypes: true` to use this option.
 
-The method to exclude defined as a `Type.method`. Where type and method matched by name.
+The method to be excluded is defined as a `Type.method`. The type and method match by name here.
 
 Examples of correct code for the `{ "ignoreMethodsOnTypes": ["Foo.bar"], "useTsTypes": true }` option:
 
@@ -96,6 +95,3 @@ interface Foo {
 const foo: Foo
 
 foo.get('string with a spaces')
-```
-
-By default, the following methods ate ignored: `Map.get`, `Map.has`, `Set.has`

--- a/docs/rules/no-unlocalized-strings.md
+++ b/docs/rules/no-unlocalized-strings.md
@@ -11,6 +11,13 @@ Check that code doesn't contain strings/templates/jsxText what should be wrapped
 
 Use additional Typescript type information. Requires [typed linting](https://typescript-eslint.io/getting-started/typed-linting/) to be setup.
 
+Will automatically exclude some built-in methods such as `Map` and `Set`
+and also cases where string literal is used as typescript constant.
+
+```ts
+const a: 'abc' = 'abc'
+```
+
 ### ignore
 
 The `ignore` option specifies exceptions not to check for
@@ -70,3 +77,25 @@ object.MyProperty = 'This is ignored'
 ```
 
 By default, the following properties are ignored: `className`, `styleName`, `type`, `id`, `width`, `height`, `displayName`
+
+### ignoreMethodsOnTypes
+
+Leverage power of Typescript to exclude methods defined on specific types.
+
+Note: You need to set `useTsTypes: true` to use this
+
+The method to exclude defined as a `Type.method`. Where type and method matched by name.
+
+Examples of correct code for the `{ "ignoreMethodsOnTypes": ["Foo.bar"], "useTsTypes": true }` option:
+
+```ts
+interface Foo {
+  get: (key: string) => string
+}
+
+const foo: Foo
+
+foo.get('string with a spaces')
+```
+
+By default, the following methods ate ignored: `Map.get`, `Map.has`, `Set.has`

--- a/tests/src/rules/no-unlocalized-strings.test.ts
+++ b/tests/src/rules/no-unlocalized-strings.test.ts
@@ -351,8 +351,35 @@ tsTester.run('no-unlocalized-strings', rule, {
       // displayName is ignored by default
       code: `MyComponent.displayName = 'MyComponent';`,
     },
+    {
+      code: `const myMap = new Map(); 
+      myMap.get("string with a spaces")
+      myMap.has("string with a spaces")`,
+      options: [{ useTsTypes: true }],
+    },
+    {
+      code: `
+      const mySet = new Set(); mySet.has("string with a spaces")`,
+      options: [{ useTsTypes: true }],
+    },
+    {
+      code: `interface Foo {get: (key: string) => string}; 
+      (foo as Foo).get("string with a spaces")`,
+      options: [{ useTsTypes: true, ignoreMethodsOnTypes: ['Foo.get'] }],
+    },
+    {
+      code: `interface Foo {get: (key: string) => string};
+      const foo: Foo;
+      foo.get("string with a spaces")`,
+      options: [{ useTsTypes: true, ignoreMethodsOnTypes: ['Foo.get'] }],
+    },
   ],
   invalid: [
+    {
+      code: `const notAMap: {get: (key: string) => string}; notAMap.get("string with a spaces")`,
+      options: [{ useTsTypes: true }],
+      errors,
+    },
     { code: `var a = 'Hello guys'`, errors },
     {
       code: `<button className={styles.btn}>loading</button>`,


### PR DESCRIPTION
fixes: https://github.com/lingui/eslint-plugin/issues/38
related: https://github.com/lingui/eslint-plugin/issues/50

Leverage power of Typescript to exclude methods defined on specific types.

The method to exclude defined as a `Type.method`. Where type and method matched by name.

Examples of correct code for the `{ "ignoreMethodsOnTypes": ["Foo.bar"], "useTsTypes": true }` option:

```ts
interface Foo {
  get: (key: string) => string
}

const foo: Foo

foo.get('string with a spaces')
```

By default, the following methods ate ignored: `Map.get`, `Map.has`, `Set.has`
