### PR TITLE
feat: support `msg` and `defineMessage` in various rules

### DIFF
--- a/docs/rules/no-expression-in-message.md
+++ b/docs/rules/no-expression-in-message.md
@@ -6,11 +6,21 @@ Such expressions would be transformed to its index position such as `Hello {0}` 
 
 Use a variable identifier instead.
 
-```jsx
-// nope ⛔️
-t`Hello ${user.name}` // => 'Hello {0}'
+Examples of invalid code with this rule:
 
-// ok ✅
+```jsx
+// invalid ⛔
+t`Hello ${user.name}` // => 'Hello {0}'
+msg`Hello ${user.name}` // => 'Hello {0}'
+defineMessage`Hello ${user.name}` // => 'Hello {0}'
+```
+
+Examples of valid code with this rule:
+
+```jsx
+// valid ✅
 const userName = user.name
 t`Hello ${userName}` // => 'Hello {userName}'
+msg`Hello ${userName}` // => 'Hello {userName}'
+defineMessage`Hello ${userName}` // => 'Hello {userName}'
 ```

--- a/docs/rules/no-single-variables-to-translate.md
+++ b/docs/rules/no-single-variables-to-translate.md
@@ -7,10 +7,20 @@ Doesn't allow single variables without text to translate like `<Trans>{variable}
 
 Such expression would pollute message catalog with useless string which has nothing to translate.
 
-```jsx
-// nope ⛔️
-<Trans>{user}</Trans>
+Examples of invalid code with this rule:
 
-// ok ✅
-<Trans>Hello {user}</Trans>
+```jsx
+// invalid ⛔️
+;<Trans>{user}</Trans>
+t`${user}`
+msg`${user}`
+```
+
+Examples of valid code with this rule:
+
+```jsx
+// valid ✅
+;<Trans>Hello {user}</Trans>
+t`Hello ${user}`
+msg`Hello ${user}`
 ```

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -50,17 +50,21 @@ export function getNearestAncestor<Type>(node: any, type: string): Type | null {
 }
 
 export const isTTaggedTemplateExpression = (node: TSESTree.TaggedTemplateExpression | null) => {
-  switch (node?.type) {
-    case TSESTree.AST_NODE_TYPES.TaggedTemplateExpression:
-      if (node.tag.type === TSESTree.AST_NODE_TYPES.Identifier) {
-        const tagName = node.tag.name
-        if (tagName === 't') {
-          return true
-        }
-      }
-    default:
-      return false
-  }
+  return (
+    node?.type === TSESTree.AST_NODE_TYPES.TaggedTemplateExpression &&
+    node.tag.type === TSESTree.AST_NODE_TYPES.Identifier &&
+    node.tag.name === 't'
+  )
+}
+
+export const isLinguiTaggedTemplateExpression = (
+  node: TSESTree.TaggedTemplateExpression | null,
+) => {
+  return (
+    node?.type === TSESTree.AST_NODE_TYPES.TaggedTemplateExpression &&
+    node.tag.type === TSESTree.AST_NODE_TYPES.Identifier &&
+    [`t`, `msg`, `defineMessage`].includes(node.tag.name)
+  )
 }
 
 export const getQuasisValue = (node: TSESTree.TemplateLiteral, trim: boolean = true) => {
@@ -109,7 +113,7 @@ export function isNodeTranslated(
     TSESTree.AST_NODE_TYPES.TaggedTemplateExpression,
   )
 
-  return taggedTemplate ? isTTaggedTemplateExpression(taggedTemplate) : false
+  return taggedTemplate ? isLinguiTaggedTemplateExpression(taggedTemplate) : false
 }
 
 export function getIdentifierName(jsxTagNameExpression: TSESTree.JSXTagNameExpression) {

--- a/src/rules/no-expression-in-message.ts
+++ b/src/rules/no-expression-in-message.ts
@@ -1,5 +1,5 @@
 import { TSESTree } from '@typescript-eslint/utils'
-import { getNearestAncestor, isTTaggedTemplateExpression } from '../helpers'
+import { getNearestAncestor, isLinguiTaggedTemplateExpression } from '../helpers'
 import { createRule } from '../create-rule'
 
 export const name = 'no-expression-in-message'
@@ -30,6 +30,14 @@ export const rule = createRule({
 
     return {
       'TemplateLiteral:exit'(node: TSESTree.TemplateLiteral) {
+        const taggedTemplate = getNearestAncestor<TSESTree.TaggedTemplateExpression>(
+          node,
+          TSESTree.AST_NODE_TYPES.TaggedTemplateExpression,
+        )
+        if (!taggedTemplate) {
+          return
+        }
+
         const noneIdentifierExpressions = node.expressions
           ? node.expressions.filter((expression) => {
               const isIdentifier = expression.type === TSESTree.AST_NODE_TYPES.Identifier
@@ -41,15 +49,9 @@ export const rule = createRule({
             })
           : []
 
-        const taggedTemplate = getNearestAncestor<TSESTree.TaggedTemplateExpression>(
-          node,
-          TSESTree.AST_NODE_TYPES.TaggedTemplateExpression,
-        )
-
         if (
           noneIdentifierExpressions.length > 0 &&
-          taggedTemplate &&
-          isTTaggedTemplateExpression(taggedTemplate)
+          isLinguiTaggedTemplateExpression(taggedTemplate)
         ) {
           context.report({
             node,

--- a/src/rules/no-single-variables-to-translate.ts
+++ b/src/rules/no-single-variables-to-translate.ts
@@ -1,11 +1,6 @@
 import { TSESTree } from '@typescript-eslint/utils'
 
-import {
-  getQuasisValue,
-  getNearestAncestor,
-  getIdentifierName,
-  isTTaggedTemplateExpression,
-} from '../helpers'
+import { getQuasisValue, getNearestAncestor, isLinguiTaggedTemplateExpression } from '../helpers'
 import { createRule } from '../create-rule'
 
 export const name = 'no-single-variable-to-translate'
@@ -47,33 +42,28 @@ export const rule = createRule({
       })
     }
     return {
-      JSXElement(node: TSESTree.JSXElement) {
-        const identifierName = getIdentifierName(node?.openingElement?.name)
-        if (identifierName === 'Trans') {
-          const isSomeJSXTextWithContent = node && hasSomeJSXTextWithContent(node.children)
-          const hasIdProperty =
-            node.openingElement.attributes.find(
-              (attr) => attr.type === 'JSXAttribute' && attr.name.name === 'id',
-            ) !== undefined
+      'JSXElement[openingElement.name.name=Trans]'(node: TSESTree.JSXElement) {
+        const hasIdProperty =
+          node.openingElement.attributes.find(
+            (attr) => attr.type === 'JSXAttribute' && attr.name.name === 'id',
+          ) !== undefined
 
-          if (!isSomeJSXTextWithContent && !hasIdProperty) {
-            context.report({
-              node,
-              messageId: 'asJsx',
-            })
-          }
+        if (!hasSomeJSXTextWithContent(node.children) && !hasIdProperty) {
+          context.report({
+            node,
+            messageId: 'asJsx',
+          })
         }
-        return
       },
       'TemplateLiteral:exit'(node: TSESTree.TemplateLiteral) {
         const taggedTemplate = getNearestAncestor<TSESTree.TaggedTemplateExpression>(
           node,
-          'TaggedTemplateExpression',
+          TSESTree.AST_NODE_TYPES.TaggedTemplateExpression,
         )
         const quasisValue = getQuasisValue(node)
         if (
           taggedTemplate &&
-          isTTaggedTemplateExpression(taggedTemplate) &&
+          isLinguiTaggedTemplateExpression(taggedTemplate) &&
           (!quasisValue || !quasisValue.length)
         ) {
           context.report({

--- a/tests/src/rules/no-expression-in-message.test.ts
+++ b/tests/src/rules/no-expression-in-message.test.ts
@@ -37,6 +37,12 @@ ruleTester.run(name, rule, {
       code: 't`Hello ${hello}`',
     },
     {
+      code: 'msg`Hello ${hello}`',
+    },
+    {
+      code: 'defineMessage`Hello ${hello}`',
+    },
+    {
       code: 't`Hello ${plural()}`',
     },
     {
@@ -58,6 +64,14 @@ ruleTester.run(name, rule, {
   invalid: [
     {
       code: 't`hello ${obj.prop}?`',
+      errors: [{ messageId: 'default' }],
+    },
+    {
+      code: 'msg`hello ${obj.prop}?`',
+      errors: [{ messageId: 'default' }],
+    },
+    {
+      code: 'defineMessage`hello ${obj.prop}?`',
       errors: [{ messageId: 'default' }],
     },
     {

--- a/tests/src/rules/no-single-varibles-to-translate.test.ts
+++ b/tests/src/rules/no-single-varibles-to-translate.test.ts
@@ -22,12 +22,18 @@ ruleTester.run(name, rule, {
       code: 't`Hello`',
       options: [],
     },
-
     {
       code: 't`Hello ${hello}`',
       options: [],
     },
-
+    {
+      code: 'msg`Hello ${hello}`',
+      options: [],
+    },
+    {
+      code: 'defineMessage`Hello ${hello}`',
+      options: [],
+    },
     {
       code: 't`${hello} Hello ${hello}`',
       options: [],
@@ -116,6 +122,16 @@ ruleTester.run(name, rule, {
     },
     {
       code: 't`${hello}`',
+      options: [],
+      errors: errorsForT,
+    },
+    {
+      code: 'msg`${hello}`',
+      options: [],
+      errors: errorsForT,
+    },
+    {
+      code: 'defineMessage`${hello}`',
       options: [],
       errors: errorsForT,
     },

--- a/tests/src/rules/t-call-in-function.test.ts
+++ b/tests/src/rules/t-call-in-function.test.ts
@@ -27,6 +27,12 @@ ruleTester.run(name, rule, {
     {
       code: 'const a = () => {t("Hello")}',
     },
+    {
+      code: 'msg`Hello`',
+    },
+    {
+      code: 'defineMessage`Hello`',
+    },
   ],
 
   invalid: [


### PR DESCRIPTION
closes https://github.com/lingui/eslint-plugin/issues/35

> +1 to `Trans` tags, and also inside `msg` (and by extension, `defineMessage` function calls)
> ```ts
>   const obj = { value: "the value" };
>   const example = msg`Expression to the right ${_obj.value} and to the left.`; // no warning here
> ```
