### PR TITLE
feat: support messages defined as MessageDescriptor

### DIFF
--- a/src/rules/no-expression-in-message.ts
+++ b/src/rules/no-expression-in-message.ts
@@ -1,5 +1,8 @@
 import { TSESTree } from '@typescript-eslint/utils'
-import { getNearestAncestor, isLinguiTaggedTemplateExpression } from '../helpers'
+import {
+  LinguiCallExpressionMessageQuery,
+  LinguiTaggedTemplateExpressionMessageQuery,
+} from '../helpers'
 import { createRule } from '../create-rule'
 
 export const name = 'no-expression-in-message'
@@ -29,15 +32,9 @@ export const rule = createRule({
     const linguiMacroFunctionNames = ['plural', 'select', 'selectOrdinal']
 
     return {
-      'TemplateLiteral:exit'(node: TSESTree.TemplateLiteral) {
-        const taggedTemplate = getNearestAncestor<TSESTree.TaggedTemplateExpression>(
-          node,
-          TSESTree.AST_NODE_TYPES.TaggedTemplateExpression,
-        )
-        if (!isLinguiTaggedTemplateExpression(taggedTemplate)) {
-          return
-        }
-
+      [`${LinguiTaggedTemplateExpressionMessageQuery}, ${LinguiCallExpressionMessageQuery}`](
+        node: TSESTree.TemplateLiteral,
+      ) {
         const noneIdentifierExpressions = node.expressions
           ? node.expressions.filter((expression) => {
               const isIdentifier = expression.type === TSESTree.AST_NODE_TYPES.Identifier

--- a/src/rules/no-single-tag-to-translate.ts
+++ b/src/rules/no-single-tag-to-translate.ts
@@ -1,5 +1,6 @@
 import { TSESTree } from '@typescript-eslint/utils'
 import { createRule } from '../create-rule'
+import { LinguiTransQuery } from '../helpers'
 
 export const name = 'no-single-tag-to-translate'
 export const rule = createRule({
@@ -26,7 +27,7 @@ export const rule = createRule({
 
   create: function (context) {
     return {
-      'JSXElement[openingElement.name.name=Trans]'(node: TSESTree.JSXElement) {
+      [LinguiTransQuery](node: TSESTree.JSXElement) {
         // delete all spaces or breaks
         const filteredChildren = node.children.filter((child: TSESTree.JSXChild) => {
           switch (child.type) {

--- a/src/rules/no-single-variables-to-translate.ts
+++ b/src/rules/no-single-variables-to-translate.ts
@@ -1,6 +1,10 @@
 import { TSESTree } from '@typescript-eslint/utils'
 
-import { getQuasisValue, getNearestAncestor, isLinguiTaggedTemplateExpression } from '../helpers'
+import {
+  getQuasisValue,
+  LinguiCallExpressionMessageQuery,
+  LinguiTaggedTemplateExpressionMessageQuery,
+} from '../helpers'
 import { createRule } from '../create-rule'
 
 export const name = 'no-single-variable-to-translate'
@@ -55,17 +59,10 @@ export const rule = createRule({
           })
         }
       },
-      'TemplateLiteral:exit'(node: TSESTree.TemplateLiteral) {
-        const taggedTemplate = getNearestAncestor<TSESTree.TaggedTemplateExpression>(
-          node,
-          TSESTree.AST_NODE_TYPES.TaggedTemplateExpression,
-        )
-        const quasisValue = getQuasisValue(node)
-        if (
-          taggedTemplate &&
-          isLinguiTaggedTemplateExpression(taggedTemplate) &&
-          (!quasisValue || !quasisValue.length)
-        ) {
+      [`${LinguiTaggedTemplateExpressionMessageQuery}, ${LinguiCallExpressionMessageQuery}`](
+        node: TSESTree.TemplateLiteral,
+      ) {
+        if (getQuasisValue(node).length === 0) {
           context.report({
             node,
             messageId: 'asFunction',

--- a/src/rules/no-trans-inside-trans.ts
+++ b/src/rules/no-trans-inside-trans.ts
@@ -1,5 +1,6 @@
 import { TSESTree } from '@typescript-eslint/utils'
 import { createRule } from '../create-rule'
+import { LinguiTransQuery } from '../helpers'
 
 export const name = 'no-trans-inside-trans'
 export const rule = createRule({
@@ -26,9 +27,7 @@ export const rule = createRule({
 
   create: function (context) {
     return {
-      'JSXElement[openingElement.name.name=Trans] JSXElement[openingElement.name.name=Trans]'(
-        node: TSESTree.JSXElement,
-      ) {
+      [`${LinguiTransQuery} ${LinguiTransQuery}`](node: TSESTree.JSXElement) {
         context.report({
           node,
           messageId: 'default',

--- a/tests/src/rules/no-expression-in-message.test.ts
+++ b/tests/src/rules/no-expression-in-message.test.ts
@@ -43,6 +43,18 @@ ruleTester.run(name, rule, {
       code: 'defineMessage`Hello ${hello}`',
     },
     {
+      code: 'b({message: `hello ${user.name}?`})',
+    },
+    {
+      code: 't({message: `hello ${user}?`})',
+    },
+    {
+      code: 'msg({message: `hello ${user}?`})',
+    },
+    {
+      code: 'defineMessage({message: `hello ${user}?`})',
+    },
+    {
       code: 't`Hello ${plural()}`',
     },
     {
@@ -72,6 +84,18 @@ ruleTester.run(name, rule, {
     },
     {
       code: 'defineMessage`hello ${obj.prop}?`',
+      errors: [{ messageId: 'default' }],
+    },
+    {
+      code: 't({message: `hello ${obj.prop}?`})',
+      errors: [{ messageId: 'default' }],
+    },
+    {
+      code: 'msg({message: `hello ${obj.prop}?`})',
+      errors: [{ messageId: 'default' }],
+    },
+    {
+      code: 'defineMessage({message: `hello ${obj.prop}?`})',
       errors: [{ messageId: 'default' }],
     },
     {

--- a/tests/src/rules/no-single-variables-to-translate.test.ts
+++ b/tests/src/rules/no-single-variables-to-translate.test.ts
@@ -20,70 +20,69 @@ ruleTester.run(name, rule, {
   valid: [
     {
       code: 't`Hello`',
-      options: [],
     },
     {
       code: 't`Hello ${hello}`',
-      options: [],
     },
     {
       code: 'msg`Hello ${hello}`',
-      options: [],
     },
     {
       code: 'defineMessage`Hello ${hello}`',
-      options: [],
     },
     {
       code: 't`${hello} Hello ${hello}`',
-      options: [],
     },
 
     {
       code: '<Trans>Hello</Trans>',
-      options: [],
     },
 
     {
       code: '<Trans>Hello {hello}</Trans>',
-      options: [],
     },
 
     {
       code: '<Trans>{hello} Hello {hello}</Trans>',
-      options: [],
     },
 
     {
       code: '<Trans><b>Hello</b></Trans>',
-      options: [],
     },
 
     {
       code: '{hello}',
-      options: [],
     },
 
     {
       code: '`${hello}`',
-      options: [],
     },
-
+    {
+      code: 'b({message: `${hello}`})',
+    },
+    {
+      code: 't({message: `Hello ${user}`})',
+    },
+    {
+      code: 'msg({message: `Hello ${user}`})',
+    },
+    {
+      code: 'defineMessage({message: `Hello ${user}`})',
+    },
     {
       code: '<Trans id={lazyTranslation.id} />',
-      options: [],
     },
   ],
 
   invalid: [
     {
       code: '<Trans>{hello}</Trans>',
-      options: [],
+
       errors: errorsForTrans,
     },
     {
       code: '<Trans>{hello} {hello}</Trans>',
-      options: [],
+
       errors: errorsForTrans,
     },
     {
@@ -93,7 +92,7 @@ ruleTester.run(name, rule, {
                     invoice.total.currency
                 )}
             </Trans>`,
-      options: [],
+
       errors: errorsForTrans,
     },
     {
@@ -117,22 +116,34 @@ ruleTester.run(name, rule, {
                     invoice.total.currency
                 )}
             </Trans>`,
-      options: [],
+
       errors: errorsForTrans,
     },
     {
       code: 't`${hello}`',
-      options: [],
+
       errors: errorsForT,
     },
     {
       code: 'msg`${hello}`',
-      options: [],
+
       errors: errorsForT,
     },
     {
       code: 'defineMessage`${hello}`',
-      options: [],
+
+      errors: errorsForT,
+    },
+    {
+      code: 't({message: `${hello}`})',
+      errors: errorsForT,
+    },
+    {
+      code: 'msg({message: `${user}`})',
+      errors: errorsForT,
+    },
+    {
+      code: 'defineMessage({message: `${user}`})',
       errors: errorsForT,
     },
   ],


### PR DESCRIPTION
Support messages defined as MessageDescriptor `` t({message: `Hello ${user}`}) `` in `no-expression-in-message` and `no-single-variables-to-translate`.