### PR TITLE
feat(text-restrictions): apply rules only for translation messagessupport different lingui signatures

### DIFF
--- a/docs/rules/text-restrictions.md
+++ b/docs/rules/text-restrictions.md
@@ -1,8 +1,8 @@
 # text-restrictions
 
-Check that strings/templates/jsxText doesn't contain patterns from the rules.
+Check that translated messages doesn't contain patterns from the rules.
 
-This rules enforces a consistency rules inside your messages.
+This rule enforces a consistency rules inside your messages.
 
 ## rules
 
@@ -20,4 +20,37 @@ each `rule` has a structure:
 - `patterns` is an array of regex or strings
 - `message` is an error message that will be displayed if restricting pattern matches text
 - `flags` is a string with regex flags for patterns
-- `isOnlyForTranslation` is a boolean indicating that patterns should be found only inside `Trans` tags or `t` tagged template
+
+## Example
+
+Restrict specific quotes to be used in the messages:
+
+```json
+{
+  "lingui/text-restrictions": [
+    "error",
+    {
+      "rules": [
+        {
+          "patterns": ["''", "’", "“"],
+          "message": "Quotes should be ' or \""
+        }
+      ]
+    }
+  ]
+}
+```
+
+Example of invalid code with this rule:
+
+```js
+t`Hello “mate“`
+msg`Hello “mate“`
+t({ message: `Hello “mate“` })
+```
+
+Example of valid code with this rule:
+
+```js
+t`Hello "mate"`
+```

--- a/src/rules/no-expression-in-message.ts
+++ b/src/rules/no-expression-in-message.ts
@@ -2,6 +2,7 @@ import { TSESTree } from '@typescript-eslint/utils'
 import {
   LinguiCallExpressionMessageQuery,
   LinguiTaggedTemplateExpressionMessageQuery,
+  LinguiTransQuery,
 } from '../helpers'
 import { createRule } from '../create-rule'
 
@@ -33,8 +34,12 @@ export const rule = createRule({
 
     return {
       [`${LinguiTaggedTemplateExpressionMessageQuery}, ${LinguiCallExpressionMessageQuery}`](
-        node: TSESTree.TemplateLiteral,
+        node: TSESTree.TemplateLiteral | TSESTree.Literal,
       ) {
+        if (node.type === TSESTree.AST_NODE_TYPES.Literal) {
+          return
+        }
+
         const noneIdentifierExpressions = node.expressions
           ? node.expressions.filter((expression) => {
               const isIdentifier = expression.type === TSESTree.AST_NODE_TYPES.Identifier
@@ -55,7 +60,7 @@ export const rule = createRule({
 
         return
       },
-      'JSXElement[openingElement.name.name=Trans] JSXExpressionContainer:not([parent.type=JSXAttribute]) > :expression'(
+      [`${LinguiTransQuery} JSXExpressionContainer:not([parent.type=JSXAttribute]) > :expression`](
         node: TSESTree.Expression,
       ) {
         const isIdentifier = node.type === TSESTree.AST_NODE_TYPES.Identifier

--- a/src/rules/no-single-variables-to-translate.ts
+++ b/src/rules/no-single-variables-to-translate.ts
@@ -1,7 +1,7 @@
 import { TSESTree } from '@typescript-eslint/utils'
 
 import {
-  getQuasisValue,
+  getText,
   LinguiCallExpressionMessageQuery,
   LinguiTaggedTemplateExpressionMessageQuery,
 } from '../helpers'
@@ -60,9 +60,9 @@ export const rule = createRule({
         }
       },
       [`${LinguiTaggedTemplateExpressionMessageQuery}, ${LinguiCallExpressionMessageQuery}`](
-        node: TSESTree.TemplateLiteral,
+        node: TSESTree.TemplateLiteral | TSESTree.Literal,
       ) {
-        if (getQuasisValue(node).length === 0) {
+        if (!getText(node)) {
           context.report({
             node,
             messageId: 'asFunction',

--- a/src/rules/no-unlocalized-strings.ts
+++ b/src/rules/no-unlocalized-strings.ts
@@ -3,9 +3,9 @@ import {
   isUpperCase,
   isAllowedDOMAttr,
   getNearestAncestor,
-  getQuasisValue,
   hasAncestorWithName,
   getIdentifierName,
+  getText,
 } from '../helpers'
 import { createRule } from '../create-rule'
 
@@ -273,7 +273,7 @@ export const rule = createRule<Option[], string>({
       },
 
       'JSXElement > JSXExpressionContainer > TemplateLiteral'(node: TSESTree.TemplateLiteral) {
-        processTextNode(node, getQuasisValue(node))
+        processTextNode(node, getText(node))
       },
 
       'JSXAttribute :matches(Literal,TemplateLiteral)'(
@@ -372,7 +372,7 @@ export const rule = createRule<Option[], string>({
 
           if (
             parent?.key?.type === TSESTree.AST_NODE_TYPES.TemplateLiteral &&
-            isUpperCase(getQuasisValue(parent?.key))
+            isUpperCase(getText(parent?.key))
           ) {
             visited.add(node)
           }
@@ -483,7 +483,7 @@ export const rule = createRule<Option[], string>({
       },
       'TemplateLiteral:exit'(node: TSESTree.TemplateLiteral) {
         if (visited.has(node)) return
-        const quasisValue = getQuasisValue(node)
+        const quasisValue = getText(node)
         if (isUpperCase(quasisValue)) return
 
         if (match(quasisValue) || !isStrMatched(quasisValue)) return

--- a/src/rules/text-restrictions.ts
+++ b/src/rules/text-restrictions.ts
@@ -1,20 +1,23 @@
 import { TSESTree } from '@typescript-eslint/utils'
 
-import { getQuasisValue, isNodeTranslated } from '../helpers'
+import {
+  getText,
+  LinguiCallExpressionMessageQuery,
+  LinguiTaggedTemplateExpressionMessageQuery,
+  LinguiTransQuery,
+} from '../helpers'
 import { createRule } from '../create-rule'
 
 export type RestrictionRule = {
   patterns: string[]
   message: string
   flags?: string
-  isOnlyForTranslation?: boolean
 }
 
 type RegexRule = {
   patterns: RegExp[]
   message: string
   flags?: string
-  isOnlyForTranslation?: boolean
 }
 
 export type Option = {
@@ -53,9 +56,6 @@ export const rule = createRule<Option[], string>({
                 message: {
                   type: 'string',
                 },
-                isOnlyForTranslation: {
-                  type: 'boolean',
-                },
               },
             },
           },
@@ -72,49 +72,33 @@ export const rule = createRule<Option[], string>({
     const {
       options: [option],
     } = context
-    if (option && option.rules) {
-      const { rules } = option
+    if (!option?.rules?.length) {
+      return {}
+    }
 
-      const rulePatterns: RegexRule[] = rules.map(
-        ({ patterns, message, flags, isOnlyForTranslation }: RestrictionRule) => ({
-          patterns: patterns.map((item: string) => new RegExp(item, flags)),
-          message,
-          isOnlyForTranslation,
-        }),
-      )
+    const { rules } = option
 
-      const onLiteral = (
-        value: string,
-        node: TSESTree.TemplateLiteral | TSESTree.Literal | TSESTree.JSXText,
-      ) => {
-        rulePatterns.forEach(({ patterns, message, isOnlyForTranslation }: RegexRule) => {
-          if (isOnlyForTranslation && !isNodeTranslated(node)) {
-            return
-          }
-          if (
-            patterns.some((item: RegExp) => {
-              return item.test(value)
-            })
-          ) {
+    const rulePatterns: RegexRule[] = rules.map(
+      ({ patterns, message, flags }: RestrictionRule) => ({
+        patterns: patterns.map((item: string) => new RegExp(item, flags)),
+        message,
+      }),
+    )
+
+    return {
+      [`${LinguiTaggedTemplateExpressionMessageQuery}, ${LinguiCallExpressionMessageQuery}, ${LinguiTransQuery} JSXText`](
+        node: TSESTree.TemplateLiteral | TSESTree.Literal,
+      ) {
+        const text = getText(node)
+
+        rulePatterns.forEach(({ patterns, message }: RegexRule) => {
+          if (patterns.some((item: RegExp) => item.test(text))) {
             context.report({ node, messageId: 'default', data: { message: message } })
           }
         })
-      }
-      return {
-        'TemplateLiteral:exit'(node: TSESTree.TemplateLiteral) {
-          const quasisValue = getQuasisValue(node)
-          onLiteral(quasisValue.trim(), node)
-          return
-        },
 
-        'Literal, JSXText'(node: TSESTree.Literal | TSESTree.JSXText) {
-          if (node.value) {
-            const trimed = node.value.toString().trim()
-            onLiteral(trimed, node)
-          }
-          return
-        },
-      }
+        return
+      },
     }
   },
 })

--- a/tests/src/rules/no-expression-in-message.test.ts
+++ b/tests/src/rules/no-expression-in-message.test.ts
@@ -49,6 +49,9 @@ ruleTester.run(name, rule, {
       code: 't({message: `hello ${user}?`})',
     },
     {
+      code: 't({message: "StringLiteral"})',
+    },
+    {
       code: 'msg({message: `hello ${user}?`})',
     },
     {

--- a/tests/src/rules/no-single-variables-to-translate.test.ts
+++ b/tests/src/rules/no-single-variables-to-translate.test.ts
@@ -33,7 +33,9 @@ ruleTester.run(name, rule, {
     {
       code: 't`${hello} Hello ${hello}`',
     },
-
+    {
+      code: 't({message: "StringLiteral"})',
+    },
     {
       code: '<Trans>Hello</Trans>',
     },

--- a/tests/src/rules/text-restrictions.test.ts
+++ b/tests/src/rules/text-restrictions.test.ts
@@ -12,7 +12,6 @@ const quotesRule: RestrictionRule = {
 const bracketRule: RestrictionRule = {
   patterns: ['<', '>', '&lt;', '&gt;'],
   message: 'Exclude <,> symbols from translations',
-  isOnlyForTranslation: true,
 }
 
 const wordRule: RestrictionRule = {
@@ -34,7 +33,7 @@ const ruleTester = new RuleTester({
 ruleTester.run<string, Option[]>('text-restrictions (ts)', rule, {
   valid: [
     {
-      code: "i18n._('Hello')",
+      code: 't`Hello`',
       options: [
         {
           rules: [quotesRule],
@@ -42,7 +41,7 @@ ruleTester.run<string, Option[]>('text-restrictions (ts)', rule, {
       ],
     },
     {
-      code: 'i18n._(`Hello ${kek}`)',
+      code: 't`Hello ${kek}`',
       options: [
         {
           rules: [quotesRule],
@@ -50,7 +49,7 @@ ruleTester.run<string, Option[]>('text-restrictions (ts)', rule, {
       ],
     },
     {
-      code: '<div>Hello</div>',
+      code: 't({message: `Hello ${kek}`})',
       options: [
         {
           rules: [quotesRule],
@@ -58,7 +57,23 @@ ruleTester.run<string, Option[]>('text-restrictions (ts)', rule, {
       ],
     },
     {
-      code: '<div>Email</div>',
+      code: 'b({message: `Hell“o“`})',
+      options: [
+        {
+          rules: [quotesRule],
+        },
+      ],
+    },
+    {
+      code: '<Trans>Hello</Trans>',
+      options: [
+        {
+          rules: [quotesRule],
+        },
+      ],
+    },
+    {
+      code: '<Trans>Email</Trans>',
       options: [
         {
           rules: [wordRule],
@@ -66,7 +81,7 @@ ruleTester.run<string, Option[]>('text-restrictions (ts)', rule, {
       ],
     },
     {
-      code: '<div>email</div>',
+      code: '<Trans>email</Trans>',
       options: [
         {
           rules: [wordRule],
@@ -101,7 +116,7 @@ ruleTester.run<string, Option[]>('text-restrictions (ts)', rule, {
 
   invalid: [
     {
-      code: "i18n._('Hell“o“')",
+      code: 't`Hell“o“`',
       options: [
         {
           rules: [quotesRule],
@@ -110,7 +125,7 @@ ruleTester.run<string, Option[]>('text-restrictions (ts)', rule, {
       errors: [{ messageId: 'default', data: { message: quotesRule.message } }],
     },
     {
-      code: 'i18n._(`Hell“o“`)',
+      code: 'msg`Hell“o“`',
       options: [
         {
           rules: [quotesRule],
@@ -119,7 +134,7 @@ ruleTester.run<string, Option[]>('text-restrictions (ts)', rule, {
       errors: [{ messageId: 'default', data: { message: quotesRule.message } }],
     },
     {
-      code: '<div>Hell“o“</div>',
+      code: 'defineMessage`Hell“o“`',
       options: [
         {
           rules: [quotesRule],
@@ -128,7 +143,34 @@ ruleTester.run<string, Option[]>('text-restrictions (ts)', rule, {
       errors: [{ messageId: 'default', data: { message: quotesRule.message } }],
     },
     {
-      code: "i18n._('Hell“o“')",
+      code: 't({message: `Hell“o“`})',
+      options: [
+        {
+          rules: [quotesRule],
+        },
+      ],
+      errors: [{ messageId: 'default', data: { message: quotesRule.message } }],
+    },
+    {
+      code: "t({message: 'Hell“o“'})",
+      options: [
+        {
+          rules: [quotesRule],
+        },
+      ],
+      errors: [{ messageId: 'default', data: { message: quotesRule.message } }],
+    },
+    {
+      code: '<Trans>Hell“o“</Trans>',
+      options: [
+        {
+          rules: [quotesRule],
+        },
+      ],
+      errors: [{ messageId: 'default', data: { message: quotesRule.message } }],
+    },
+    {
+      code: 't`Hell“o“`',
       options: [
         {
           rules: [
@@ -146,7 +188,7 @@ ruleTester.run<string, Option[]>('text-restrictions (ts)', rule, {
       ],
     },
     {
-      code: '<div>E-mail</div>',
+      code: '<Trans>E-mail</Trans>',
       options: [
         {
           rules: [wordRule],
@@ -155,7 +197,7 @@ ruleTester.run<string, Option[]>('text-restrictions (ts)', rule, {
       errors: [{ messageId: 'default', data: { message: wordRule.message } }],
     },
     {
-      code: '<div>e-mail</div>',
+      code: '<Trans>e-mail</Trans>',
       options: [
         {
           rules: [wordRule],


### PR DESCRIPTION
text-restriction rule had a very strange setting `isOnlyForTranslation` which was false by default. It applied restriction rules to all string literals not only for those belonging to lingui.

I think this is not a reasonable default, and it might had sense for author's private project, but doesn't have a sense for lingui. 

So this PR removes this settings. Make it only check the lingui messages, and also a complete refactoring of that rule. 