### PR TITLE
feat(no-expression-in-message): correctly handle {' '} in JSX, report for each found expression

### DIFF
--- a/tests/src/rules/no-expression-in-message.test.ts
+++ b/tests/src/rules/no-expression-in-message.test.ts
@@ -75,6 +75,18 @@ ruleTester.run(name, rule, {
     {
       code: '<Trans>Hello {userName}</Trans>',
     },
+    {
+      name: 'Should not be triggered for JSX Whitespace expression',
+      code: "<Trans>Did you mean{' '}<span>something</span>{` `}</Trans>",
+    },
+    {
+      name: 'Template literals as children with identifiers',
+      code: ' <Trans>{`How much is ${expression}? ${count}`}</Trans>',
+    },
+    {
+      name: 'Strings as children are preserved',
+      code: '<Trans>{"hello {count, plural, one {world} other {worlds}}"}</Trans>',
+    },
   ],
   invalid: [
     {
@@ -102,7 +114,17 @@ ruleTester.run(name, rule, {
       errors: [{ messageId: 'default' }],
     },
     {
+      name: 'Should trigger for each expression in the message',
+      code: 't`hello ${obj.prop} ${obj.prop}?`',
+      errors: [{ messageId: 'default' }, { messageId: 'default' }],
+    },
+    {
       code: '<Trans>Hello {obj.prop}</Trans>',
+      errors: [{ messageId: 'default' }],
+    },
+    {
+      name: 'Template literals as children with expressions',
+      code: '<Trans>{`How much is ${obj.prop}?`}</Trans>',
       errors: [{ messageId: 'default' }],
     },
     {


### PR DESCRIPTION
closes https://github.com/lingui/eslint-plugin/issues/67

* now `no-expression-in-message` correctly handles text in the `JSXExpressionContainer` in the `<Trans>` component. (e.g `` <Trans>{`How much is ${obj.prop}?`}</Trans> ``) I don't know why someone should do that, but it supported by lingui macro, so the eslint rule just followed a logic. 
* rule now will report every expression in the mesage separately, so for the `` t`hello ${obj.prop} ${obj.prop}?` `` it will report 2 errors, and IDE will highlight each expression separately instead of the whole message. 
* `{' '}` don't triggering an issue nymore, as it fails into first category (text)