### PR TITLE
fix: no-single-variables-to-translate renamed to no-single-variable...

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,7 @@ const plugin = {
 const recommendedRules: { [K in RuleKey as `lingui/${K}`]?: FlatConfig.RuleLevel } = {
   'lingui/t-call-in-function': 'error',
   'lingui/no-single-tag-to-translate': 'warn',
-  'lingui/no-single-variable-to-translate': 'warn',
+  'lingui/no-single-variables-to-translate': 'warn',
   'lingui/no-trans-inside-trans': 'warn',
 }
 

--- a/src/rules/no-single-variables-to-translate.ts
+++ b/src/rules/no-single-variables-to-translate.ts
@@ -7,7 +7,7 @@ import {
 } from '../helpers'
 import { createRule } from '../create-rule'
 
-export const name = 'no-single-variable-to-translate'
+export const name = 'no-single-variables-to-translate'
 export const rule = createRule({
   name,
   meta: {


### PR DESCRIPTION
b57329b renamed the rule from `no-single-variables-to-translate` to `no-single-variable-to-translate`. I assume this was a mistake, since all the files, docs etc. still refer to the rule as `no-single-variables-to-translate` (plural) as it was named before v0.4.0.