### PR TITLE
feat(no-unlocalized-strings): add regex patterns support

### DIFF
--- a/docs/rules/no-unlocalized-strings.md
+++ b/docs/rules/no-unlocalized-strings.md
@@ -1,6 +1,6 @@
 # no-unlocalized-strings
 
-Check that code doesn't contain strings/templates/jsxText what should be wrapped into `<Trans>` or `i18n`
+Ensures all strings, templates, and JSX text are properly wrapped with `<Trans>`, `t`, or `msg` for translation.
 
 > [!IMPORTANT]  
 > This rule might use type information. You can enable it with `{useTsTypes: true}`
@@ -31,8 +31,7 @@ const a = <div color="rgba(100, 100, 100, 0.4)"></div>
 
 ### ignoreFunction
 
-The `ignoreFunction` option specifies exceptions not check for
-function calls whose names match one of regexp patterns.
+The `ignoreFunction` option specifies exceptions not check for function calls with specified names.
 
 Examples of correct code for the `{ "ignoreFunction": ["showIntercomMessage"] }` option:
 
@@ -51,6 +50,17 @@ const labelVariants = cva('text-form-input-content-helper', {
 })
 ```
 
+`ignoreFunction` also supports patterns for member expression calls:
+
+Example of valid code with `{ "ignoreFunction": ["console.log"] }`
+
+```js
+/*eslint lingui/no-unlocalized-strings: ["error", { "ignoreFunction": ["console.log"] }]*/
+const bar = console.log('Please, write me')
+```
+
+**Note!** Patterns could be specified only for one level deep. Pattern specified as `foo.bar.baz` will not work.
+
 ### ignoreAttribute
 
 The `ignoreAttribute` option specifies exceptions not to check for JSX attributes that match one of ignored attributes.
@@ -64,6 +74,34 @@ const element = <div style={{ margin: '1rem 2rem' }} />
 
 By default, the following attributes are ignored: `className`, `styleName`, `type`, `id`, `width`, `height`
 
+#### regex
+
+The regex property is used to specify the regex patterns for ignored attributes
+
+```json
+{
+  "no-unlocalized-strings": [
+    "error",
+    {
+      "ignoreAttribute": [
+        {
+          "regex": {
+            "pattern": "classname",
+            "flags": "i"
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+Examples of **correct** code for regex option:
+
+```jsx
+const element = <div wrapperClassName="absolute top-1/2 left-1/2" />
+```
+
 ### strictAttribute
 
 The `strictAttribute` option specifies JSX attributes which will always be checked regardless of `ignore`
@@ -76,6 +114,33 @@ Examples of incorrect code for the `{ "strictAttribute": ["alt"] }` option:
 const element = <div alt="IMAGE" />
 ```
 
+#### regex
+
+The regex property is used to specify the regex patterns for attributes
+
+```json
+{
+  "no-unlocalized-strings": [
+    "error",
+    {
+      "strictAttribute": [
+        {
+          "regex": {
+            "pattern": "^desc.*"
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+Examples of **incorrect** code for regex option:
+
+```jsx
+const element = <div description="IMAGE" />
+```
+
 ### ignoreProperty
 
 The `ignoreProperty` option specifies property names not to check.
@@ -85,9 +150,46 @@ Examples of correct code for the `{ "ignoreProperty": ["myProperty"] }` option:
 ```jsx
 const test = { myProperty: 'This is ignored' }
 object.MyProperty = 'This is ignored'
+
+class MyClass {
+  myProperty = 'This is ignored'
+}
 ```
 
-By default, the following properties are ignored: `className`, `styleName`, `type`, `id`, `width`, `height`, `displayName`
+By default, UPPERCASED and the following properties written are ignored: `className`, `styleName`, `type`, `id`, `width`, `height`, `displayName`
+
+#### regex
+
+The regex property is used to specify the regex patterns for ignored properties
+
+```json
+{
+  "no-unlocalized-strings": [
+    "error",
+    {
+      "ignoreProperty": [
+        {
+          "regex": {
+            "pattern": "classname",
+            "flags": "i"
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+Examples of **correct** code for regex option:
+
+```jsx
+const test = { wrapperClassName: 'This is ignored' }
+object.wrapperClassName = 'This is ignored'
+
+class MyClass {
+  wrapperClassName = 'This is ignored'
+}
+```
 
 ### ignoreMethodsOnTypes
 

--- a/docs/rules/no-unlocalized-strings.md
+++ b/docs/rules/no-unlocalized-strings.md
@@ -1,43 +1,42 @@
 # no-unlocalized-strings
 
-Ensures all strings, templates, and JSX text are properly wrapped with `<Trans>`, `t`, or `msg` for translation.
+Ensures that all string literals, templates, and JSX text are wrapped using `<Trans>`, `t`, or `msg` for localization.
 
 > [!IMPORTANT]  
-> This rule might use type information. You can enable it with `{useTsTypes: true}`
+> This rule may require TypeScript type information. Enable this feature by setting `{ useTsTypes: true }`.
 
 ## Options
 
-### useTsTypes
+### `useTsTypes`
 
-Use additional TypeScript type information. Requires [typed linting](https://typescript-eslint.io/getting-started/typed-linting/) to be setup.
+Enables the rule to use TypeScript type information. Requires [typed linting](https://typescript-eslint.io/getting-started/typed-linting/) to be configured.
 
-Will automatically exclude some built-in methods such as `Map` and `Set`, and also cases where a string literal is used as a TypeScript constant:
+This option automatically excludes built-in methods such as `Map` and `Set`, and cases where string literals are used as TypeScript constants, e.g.:
 
 ```ts
 const a: 'abc' = 'abc'
 ```
 
-### ignore
+### `ignore`
 
-The `ignore` option specifies exceptions not to check for
-literal strings that match one of regexp patterns.
+Specifies patterns for string literals to ignore. Strings matching any of the provided regular expressions will not trigger the rule.
 
-Examples of correct code for the `{ "ignore": ["rgba"] }` option:
+Example for `{ "ignore": ["rgba"] }`:
 
 ```jsx
-/*eslint lingui/no-unlocalized-strings ["error", {"ignore": ["rgba"]}]*/
-const a = <div color="rgba(100, 100, 100, 0.4)"></div>
+/*eslint lingui/no-unlocalized-strings: ["error", {"ignore": ["rgba"]}]*/
+const color = <div style={{ color: 'rgba(100, 100, 100, 0.4)' }} />
 ```
 
-### ignoreFunction
+### `ignoreFunction`
 
-The `ignoreFunction` option specifies exceptions not check for function calls with specified names.
+Specifies functions whose string arguments should be ignored.
 
-Examples of correct code for the `{ "ignoreFunction": ["showIntercomMessage"] }` option:
+Example of `correct` code with this option:
 
 ```js
-/*eslint lingui/no-unlocalized-strings: ["error", { "ignoreFunction": ["showIntercomMessage"] }]*/
-const bar = showIntercomMessage('Please, write me')
+/*eslint lingui/no-unlocalized-strings: ["error", {"ignoreFunction": ["showIntercomMessage"]}]*/
+showIntercomMessage('Please write me')
 
 /*eslint lingui/no-unlocalized-strings: ["error", { "ignoreFunction": ["cva"] }]*/
 const labelVariants = cva('text-form-input-content-helper', {
@@ -50,33 +49,31 @@ const labelVariants = cva('text-form-input-content-helper', {
 })
 ```
 
-`ignoreFunction` also supports patterns for member expression calls:
-
-Example of valid code with `{ "ignoreFunction": ["console.log"] }`
+This option also supports member expressions. Example for `{ "ignoreFunction": ["console.log"] }`:
 
 ```js
-/*eslint lingui/no-unlocalized-strings: ["error", { "ignoreFunction": ["console.log"] }]*/
-const bar = console.log('Please, write me')
+/*eslint lingui/no-unlocalized-strings: ["error", {"ignoreFunction": ["console.log"]}]*/
+console.log('Log this message')
 ```
 
-**Note!** Patterns could be specified only for one level deep. Pattern specified as `foo.bar.baz` will not work.
+> **Note:** Only single-level patterns are supported. For instance, `foo.bar.baz` will not be matched.
 
-### ignoreAttribute
+### `ignoreAttribute`
 
-The `ignoreAttribute` option specifies exceptions not to check for JSX attributes that match one of ignored attributes.
+Specifies JSX attributes that should be ignored. By default, the attributes `className`, `styleName`, `type`, `id`, `width`, and `height` are ignored.
 
-Examples of correct code for the `{ "ignoreAttribute": ["style"] }` option:
+Example for `{ "ignoreAttribute": ["style"] }`:
 
 ```jsx
-/*eslint lingui/no-unlocalized-strings: ["error", { "ignoreAttribute": ["style"] }]*/
+/*eslint lingui/no-unlocalized-strings: ["error", {"ignoreAttribute": ["style"]}]*/
 const element = <div style={{ margin: '1rem 2rem' }} />
 ```
 
-By default, the following attributes are ignored: `className`, `styleName`, `type`, `id`, `width`, `height`
+#### `regex`
 
-#### regex
+Defines regex patterns for ignored attributes.
 
-The regex property is used to specify the regex patterns for ignored attributes
+Example:
 
 ```json
 {
@@ -96,27 +93,28 @@ The regex property is used to specify the regex patterns for ignored attributes
 }
 ```
 
-Examples of **correct** code for regex option:
+Example of **correct** code:
 
 ```jsx
 const element = <div wrapperClassName="absolute top-1/2 left-1/2" />
 ```
 
-### strictAttribute
+### `strictAttribute`
 
-The `strictAttribute` option specifies JSX attributes which will always be checked regardless of `ignore`
-option or any built-in exceptions.
+Specifies JSX attributes that should always be checked, regardless of other `ignore` settings or defaults.
 
-Examples of incorrect code for the `{ "strictAttribute": ["alt"] }` option:
+Example for `{ "strictAttribute": ["alt"] }`:
 
 ```jsx
-/*eslint lingui/no-unlocalized-strings: ["error", { "strictAttribute": ["alt"] }]*/
-const element = <div alt="IMAGE" />
+/*eslint lingui/no-unlocalized-strings: ["error", {"strictAttribute": ["alt"]}]*/
+const element = <img alt="IMAGE" />
 ```
 
-#### regex
+#### `regex`
 
-The regex property is used to specify the regex patterns for attributes
+Defines regex patterns for attributes that must always be checked.
+
+Example:
 
 ```json
 {
@@ -135,32 +133,32 @@ The regex property is used to specify the regex patterns for attributes
 }
 ```
 
-Examples of **incorrect** code for regex option:
+Examples of **incorrect** code:
 
 ```jsx
 const element = <div description="IMAGE" />
 ```
 
-### ignoreProperty
+### `ignoreProperty`
 
-The `ignoreProperty` option specifies property names not to check.
+Specifies object property names whose values should be ignored. By default, UPPERCASED properties and `className`, `styleName`, `type`, `id`, `width`, `height`, and `displayName` are ignored.
 
-Examples of correct code for the `{ "ignoreProperty": ["myProperty"] }` option:
+Example for `{ "ignoreProperty": ["myProperty"] }`:
 
 ```jsx
-const test = { myProperty: 'This is ignored' }
-object.MyProperty = 'This is ignored'
+const obj = { myProperty: 'Ignored value' }
+obj.myProperty = 'Ignored value'
 
 class MyClass {
-  myProperty = 'This is ignored'
+  myProperty = 'Ignored value'
 }
 ```
 
-By default, UPPERCASED and the following properties written are ignored: `className`, `styleName`, `type`, `id`, `width`, `height`, `displayName`
+#### `regex`
 
-#### regex
+Defines regex patterns for ignored properties.
 
-The regex property is used to specify the regex patterns for ignored properties
+Example:
 
 ```json
 {
@@ -180,26 +178,26 @@ The regex property is used to specify the regex patterns for ignored properties
 }
 ```
 
-Examples of **correct** code for regex option:
+Examples of **correct** code:
 
 ```jsx
-const test = { wrapperClassName: 'This is ignored' }
-object.wrapperClassName = 'This is ignored'
+const obj = { wrapperClassName: 'Ignored value' }
+obj.wrapperClassName = 'Ignored value'
 
 class MyClass {
-  wrapperClassName = 'This is ignored'
+  wrapperClassName = 'Ignored value'
 }
 ```
 
-### ignoreMethodsOnTypes
+### `ignoreMethodsOnTypes`
 
-Leverage the power of TypeScript to exclude methods defined on specific types.
+Uses TypeScript type information to ignore methods defined on specific types.
 
-Note: You must set `useTsTypes: true` to use this option.
+Requires `useTsTypes: true`.
 
-The method to be excluded is defined as a `Type.method`. The type and method match by name here.
+Specify methods as `Type.method`, where both the type and method are matched by name.
 
-Examples of correct code for the `{ "ignoreMethodsOnTypes": ["Foo.bar"], "useTsTypes": true }` option:
+Example for `{ "ignoreMethodsOnTypes": ["Foo.get"], "useTsTypes": true }`:
 
 ```ts
 interface Foo {
@@ -207,8 +205,7 @@ interface Foo {
 }
 
 const foo: Foo
-
-foo.get('string with a spaces')
+foo.get('Some string')
 ```
 
 The following methods are ignored by default: `Map.get`, `Map.has`, `Set.has`.

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -29,8 +29,10 @@ export const LinguiCallExpressionMessageQuery =
  */
 export const LinguiTransQuery = 'JSXElement[openingElement.name.name=Trans]'
 
+export const UpperCaseRegexp = /^[A-Z_-]+$/
+
 export function isUpperCase(str: string) {
-  return /^[A-Z_-]+$/.test(str)
+  return UpperCaseRegexp.test(str)
 }
 
 export function isNativeDOMTag(str: string) {
@@ -116,4 +118,28 @@ export function getIdentifierName(jsxTagNameExpression: TSESTree.JSXTagNameExpre
     default:
       return null
   }
+}
+
+export function isLiteral(node: TSESTree.Node | undefined): node is TSESTree.Literal {
+  return node?.type === TSESTree.AST_NODE_TYPES.Literal
+}
+
+export function isTemplateLiteral(
+  node: TSESTree.Node | undefined,
+): node is TSESTree.TemplateLiteral {
+  return node?.type === TSESTree.AST_NODE_TYPES.TemplateLiteral
+}
+
+export function isIdentifier(node: TSESTree.Node | undefined): node is TSESTree.Identifier {
+  return (node as TSESTree.Node)?.type === TSESTree.AST_NODE_TYPES.Identifier
+}
+
+export function isMemberExpression(
+  node: TSESTree.Node | undefined,
+): node is TSESTree.MemberExpression {
+  return (node as TSESTree.Node)?.type === TSESTree.AST_NODE_TYPES.MemberExpression
+}
+
+export function isJSXAttribute(node: TSESTree.Node | undefined): node is TSESTree.JSXAttribute {
+  return (node as TSESTree.Node)?.type === TSESTree.AST_NODE_TYPES.JSXAttribute
 }

--- a/src/rules/no-single-variables-to-translate.ts
+++ b/src/rules/no-single-variables-to-translate.ts
@@ -2,6 +2,7 @@ import { TSESTree } from '@typescript-eslint/utils'
 
 import {
   getText,
+  isJSXAttribute,
   LinguiCallExpressionMessageQuery,
   LinguiTaggedTemplateExpressionMessageQuery,
 } from '../helpers'
@@ -49,7 +50,7 @@ export const rule = createRule({
       'JSXElement[openingElement.name.name=Trans]'(node: TSESTree.JSXElement) {
         const hasIdProperty =
           node.openingElement.attributes.find(
-            (attr) => attr.type === 'JSXAttribute' && attr.name.name === 'id',
+            (attr) => isJSXAttribute(attr) && attr.name.name === 'id',
           ) !== undefined
 
         if (!hasSomeJSXTextWithContent(node.children) && !hasIdProperty) {

--- a/tests/src/rules/no-unlocalized-strings.test.ts
+++ b/tests/src/rules/no-unlocalized-strings.test.ts
@@ -16,8 +16,7 @@ const ruleTester = new RuleTester({
   },
 })
 
-const message = 'disallow literal string'
-const errors = [{ messageId: 'default', data: { message } }] // default errors
+const errors = [{ messageId: 'default' }] // default errors
 
 ruleTester.run<string, Option[]>(name, rule, {
   valid: [
@@ -134,6 +133,10 @@ ruleTester.run<string, Option[]>(name, rule, {
     { code: '<button type={`button`} for={`form-id`} />' },
     { code: '<DIV foo="bar" />', options: [{ ignoreAttribute: ['foo'] }] },
     { code: '<DIV foo={`Bar`} />', options: [{ ignoreAttribute: ['foo'] }] },
+    {
+      code: '<DIV wrapperClassName={`Bar`} />',
+      options: [{ ignoreAttribute: [{ regex: { pattern: 'className', flags: 'i' } }] }],
+    },
     { code: '<DIV foo={`bar`} />' },
     { code: '<DIV foo="bar" />' },
     { code: 'a + `b`' },
@@ -177,8 +180,16 @@ ruleTester.run<string, Option[]>(name, rule, {
     },
     { code: `const test = { id: 'This is not localized' }` },
     {
-      code: `const test = { text: 'This is not localized' }`,
-      options: [{ ignoreProperty: ['text'] }],
+      code: `const test = { myProp: 'This is not localized' }`,
+      options: [{ ignoreProperty: ['myProp'] }],
+    },
+    {
+      code: `const test = { ['myProp']: 'This is not localized' }`,
+      options: [{ ignoreProperty: ['myProp'] }],
+    },
+    {
+      code: `const test = { wrapperClassName: 'This is not localized' }`,
+      options: [{ ignoreProperty: [{ regex: { pattern: 'className', flags: 'i' } }] }],
     },
     { code: `obj["key with space"] = 5` },
     { code: `obj[\`key with space\`] = 5` },
@@ -189,7 +200,7 @@ ruleTester.run<string, Option[]>(name, rule, {
     { code: "<Select value='Hello' one='2' notOther='3' /> ", errors },
     { code: "<Plural notValue='Hello' one='2' other='3' /> ", errors },
     { code: "<Select notValue='Hello' one='2' other='3' /> ", errors },
-    { code: '<div>hello &nbsp; </div>', errors },
+    { code: '<div>hello &nbsp; </div>', errors: [{ messageId: 'forJsxText' }] },
     { code: 'const a = `Hello ${nice}`', errors },
     { code: 'export const a = `hello string`;', errors },
     { code: "const ge = 'Select tax code'", errors },
@@ -222,10 +233,15 @@ ruleTester.run<string, Option[]>(name, rule, {
       code: 'class Form extends Component { property = "Something" };',
       errors,
     },
-    { code: '<img alt="BLA" />', only: true, options: [{ strictAttribute: ['alt'] }], errors },
-    { code: '<div>foo</div>', errors },
-    { code: '<div>Foo</div>', errors },
-    { code: '<div>FOO</div>', errors },
+    { code: '<img alt="BLA" />', options: [{ strictAttribute: ['alt'] }], errors },
+    {
+      code: '<img altAaa="BLA" />',
+      options: [{ strictAttribute: [{ regex: { pattern: '^alt' } }] }],
+      errors,
+    },
+    { code: '<div>foo</div>', errors: [{ messageId: 'forJsxText' }] },
+    { code: '<div>Foo</div>', errors: [{ messageId: 'forJsxText' }] },
+    { code: '<div>FOO</div>', errors: [{ messageId: 'forJsxText' }] },
     { code: '<DIV foo="Bar" />', errors },
     { code: '<img src="./image.png" alt="some image" />', errors },
     { code: '<button aria-label="Close" type="button" />', errors },
@@ -236,10 +252,7 @@ ruleTester.run<string, Option[]>(name, rule, {
             ? 'Search'
             : 'Search for accounts, merchants, and more...'
     }`,
-      errors: [
-        { messageId: 'default', data: { message } },
-        { messageId: 'default', data: { message } },
-      ],
+      errors: [{ messageId: 'default' }, { messageId: 'default' }],
     },
   ],
 })
@@ -279,7 +292,7 @@ jsxTester.run('no-unlocalized-strings', rule, {
   invalid: [
     {
       code: '<Component>Abc</Component>',
-      errors,
+      errors: [{ messageId: 'forJsxText' }],
     },
     {
       code: '<Component>{"Hello"}</Component>',
@@ -291,7 +304,7 @@ jsxTester.run('no-unlocalized-strings', rule, {
     },
     {
       code: '<Component>abc</Component>',
-      errors,
+      errors: [{ messageId: 'forJsxText' }],
     },
     {
       code: "<Component>{'abc'}</Component>",
@@ -303,10 +316,7 @@ jsxTester.run('no-unlocalized-strings', rule, {
     },
     {
       code: '<Component>{someVar === 1 ? `Abc` : `Def`}</Component>',
-      errors: [
-        { messageId: 'default', data: { message } },
-        { messageId: 'default', data: { message } },
-      ],
+      errors: [{ messageId: 'default' }, { messageId: 'default' }],
     },
   ],
 })
@@ -383,12 +393,12 @@ tsTester.run('no-unlocalized-strings', rule, {
     {
       code: `<button className={styles.btn}>loading</button>`,
       filename: 'a.tsx',
-      errors,
+      errors: [{ messageId: 'forJsxText' }],
     },
     {
       code: `<button className={styles.btn}>Loading</button>`,
       filename: 'a.tsx',
-      errors,
+      errors: [{ messageId: 'forJsxText' }],
     },
     {
       code: "function Button({ t= 'Name'  }: {t: 'name' &  'Abs'}){} ",
@@ -405,10 +415,7 @@ tsTester.run('no-unlocalized-strings', rule, {
             ? 'Search'
             : 'Search for accounts, merchants, and more...'
     }`,
-      errors: [
-        { messageId: 'default', data: { message } },
-        { messageId: 'default', data: { message } },
-      ],
+      errors: [{ messageId: 'default' }, { messageId: 'default' }],
     },
   ],
 })


### PR DESCRIPTION
* improved error messages, instead of "disallow literal string" it now will show 
   ```
    "String not marked for translation. Wrap it with t``, <Trans>, or msg``." 
   ```
* added support for regex patterns for `ignoreAttribute`, `strictAttribute`, `ignoreProperty` options
* refactored code, make it cleaner, removed duplicating logic
* refined documentation for that rule