### PR TITLE
feat(no-unlocalized-strings): add ignoreVariable option + refactor options

### DIFF
--- a/docs/rules/no-unlocalized-strings.md
+++ b/docs/rules/no-unlocalized-strings.md
@@ -189,6 +189,46 @@ class MyClass {
 }
 ```
 
+### `ignoreVariable`
+
+Specifies variable name whose values should be ignored. By default, UPPERCASED variables are ignored.
+
+Example for `{ "ignoreVariable": ["myVariable"] }`:
+
+```jsx
+const myVariable = 'Ignored value'
+```
+
+#### `regex`
+
+Defines regex patterns for ignored variables.
+
+Example:
+
+```json
+{
+  "no-unlocalized-strings": [
+    "error",
+    {
+      "ignoreVariable": [
+        {
+          "regex": {
+            "pattern": "classname",
+            "flags": "i"
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+Examples of **correct** code:
+
+```jsx
+const wrapperClassName = 'Ignored value'
+```
+
 ### `ignoreMethodsOnTypes`
 
 Uses TypeScript type information to ignore methods defined on specific types.

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -31,10 +31,6 @@ export const LinguiTransQuery = 'JSXElement[openingElement.name.name=Trans]'
 
 export const UpperCaseRegexp = /^[A-Z_-]+$/
 
-export function isUpperCase(str: string) {
-  return UpperCaseRegexp.test(str)
-}
-
 export function isNativeDOMTag(str: string) {
   return DOM_TAGS.includes(str)
 }

--- a/tests/src/rules/no-unlocalized-strings.test.ts
+++ b/tests/src/rules/no-unlocalized-strings.test.ts
@@ -193,6 +193,18 @@ ruleTester.run<string, Option[]>(name, rule, {
     },
     { code: `obj["key with space"] = 5` },
     { code: `obj[\`key with space\`] = 5` },
+    { code: `const FOO = "Hello!"` },
+    { code: `let FOO = "Hello!"` },
+    { code: `var FOO = "Hello!"` },
+
+    {
+      code: `const test = "Hello!"`,
+      options: [{ ignoreVariable: ['test'] }],
+    },
+    {
+      code: `const wrapperClassName  = "Hello!"`,
+      options: [{ ignoreVariable: [{ regex: { pattern: 'className', flags: 'i' } }] }],
+    },
   ],
 
   invalid: [


### PR DESCRIPTION
Preparing the code of the rule to be fully configurable from options. Extract hardcoded pieces and add options to configure them. 

This PR adds `ignoreVariable` options and doesn't bring any breaking changes. 