### PR TITLE
feat(no-unlocalized-strings): add patterns for ignore functions

### DIFF
--- a/docs/rules/no-unlocalized-strings.md
+++ b/docs/rules/no-unlocalized-strings.md
@@ -56,7 +56,24 @@ This option also supports member expressions. Example for `{ "ignoreFunction": [
 console.log('Log this message')
 ```
 
-> **Note:** Only single-level patterns are supported. For instance, `foo.bar.baz` will not be matched.
+You can use patterns (processed by [micromatch](https://www.npmjs.com/package/micromatch)) to match function calls.
+
+```js
+/*eslint lingui/no-unlocalized-strings: ["error", {"ignoreFunction": ["console.*"]}]*/
+console.log('Log this message')
+```
+
+```js
+/*eslint lingui/no-unlocalized-strings: ["error", {"ignoreFunction": ["*.headers.set"]}]*/
+context.headers.set('Authorization', `Bearer ${token}`)
+```
+
+Dynamic segments are replaced with `$`, you can target them as
+
+```js
+/*eslint lingui/no-unlocalized-strings: ["error", {"ignoreFunction": ["foo.$.set"]}]*/
+foo[getName()].set('Hello')
+```
 
 ### `ignoreAttribute`
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "**/*": "prettier --write --ignore-unknown"
   },
   "dependencies": {
-    "@typescript-eslint/utils": "^8.0.0"
+    "@typescript-eslint/utils": "^8.0.0",
+    "micromatch": "^4.0.0"
   },
   "peerDependencies": {
     "eslint": "^8.37.0 || ^9.0.0"
@@ -38,6 +39,7 @@
   "devDependencies": {
     "@types/eslint": "^8.40.2",
     "@types/jest": "^29.5.13",
+    "@types/micromatch": "^4.0.9",
     "@types/node": "^20.3.3",
     "@typescript-eslint/parser": "^8.0.0",
     "@typescript-eslint/rule-tester": "^8.0.0",

--- a/src/helpers.test.ts
+++ b/src/helpers.test.ts
@@ -1,0 +1,29 @@
+import { parse } from '@typescript-eslint/parser'
+import { TSESTree } from '@typescript-eslint/utils'
+import { buildCalleePath } from './helpers'
+
+describe('buildCalleePath', () => {
+  function buildCallExp(code: string) {
+    const t = parse(code)
+
+    return (t.body[0] as TSESTree.ExpressionStatement).expression as TSESTree.CallExpression
+  }
+
+  it('Should build callee path', () => {
+    const exp = buildCallExp('one.two.three.four()')
+
+    expect(buildCalleePath(exp.callee)).toBe('one.two.three.four')
+  })
+
+  it('Should build with dynamic element', () => {
+    const exp = buildCallExp('one.two.three[getProp()]()')
+
+    expect(buildCalleePath(exp.callee)).toBe('one.two.three.$')
+  })
+
+  it('Should build with dynamic first element', () => {
+    const exp = buildCallExp('getData().two.three.four()')
+
+    expect(buildCalleePath(exp.callee)).toBe('$.two.three.four')
+  })
+})

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -139,3 +139,26 @@ export function isMemberExpression(
 export function isJSXAttribute(node: TSESTree.Node | undefined): node is TSESTree.JSXAttribute {
   return (node as TSESTree.Node)?.type === TSESTree.AST_NODE_TYPES.JSXAttribute
 }
+
+export function buildCalleePath(node: TSESTree.Expression) {
+  let current = node
+
+  const path: string[] = []
+
+  const push = (exp: TSESTree.Node) => {
+    if (isIdentifier(exp)) {
+      path.push(exp.name)
+    } else {
+      path.push('$')
+    }
+  }
+
+  while (isMemberExpression(current)) {
+    push(current.property)
+    current = current.object
+  }
+
+  push(current)
+
+  return path.reverse().join('.')
+}

--- a/tests/src/rules/no-unlocalized-strings.test.ts
+++ b/tests/src/rules/no-unlocalized-strings.test.ts
@@ -28,6 +28,26 @@ ruleTester.run<string, Option[]>(name, rule, {
       code: 'custom.wrapper()({message: "Hello!"})',
       options: [{ ignoreFunction: ['custom.wrapper'] }],
     },
+    {
+      name: 'Should ignore calls using complex object.method expression',
+      code: 'console.log("Hello")',
+      options: [{ ignoreFunction: ['console.log'] }],
+    },
+    {
+      name: 'Should ignore method calls using pattern',
+      code: 'console.log("Hello"); console.error("Hello");',
+      options: [{ ignoreFunction: ['console.*'] }],
+    },
+    {
+      name: 'Should ignore methods multilevel',
+      code: 'context.headers.set("Hello"); level.context.headers.set("Hello");',
+      options: [{ ignoreFunction: ['*.headers.set'] }],
+    },
+    {
+      name: 'Should ignore methods with dynamic segment ',
+      code: 'getData().two.three.four("Hello")',
+      options: [{ ignoreFunction: ['*.three.four'] }],
+    },
     { code: 'name === `Hello brat` || name === `Nice have`' },
     { code: 'switch(a){ case `a`: break; default: break;}' },
     { code: 'a.indexOf(`ios`)' },
@@ -69,7 +89,7 @@ ruleTester.run<string, Option[]>(name, rule, {
     {
       code: 'document.removeEventListener("click", (event) => { event.preventDefault() })',
     },
-    { code: 'window.postMessage("message", "*")' },
+    { code: 'window.postMessage("message", "Ola!")' },
     { code: 'document.getElementById("some-id")' },
     { code: 'require("hello");' },
     { code: 'const a = require(["hello"]);' },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1023,6 +1023,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/braces@npm:*":
+  version: 3.0.4
+  resolution: "@types/braces@npm:3.0.4"
+  checksum: 10c0/05220f330814364318a1c2f403046d717690cabf3adc8417357b0b12713f92768cf9df76e0e25212b5a2727c8c56765ff19a284c7ece39e0985d0d6fadb6c4aa
+  languageName: node
+  linkType: hard
+
 "@types/eslint@npm:^8.40.2":
   version: 8.40.2
   resolution: "@types/eslint@npm:8.40.2"
@@ -1088,6 +1095,15 @@ __metadata:
   version: 7.0.15
   resolution: "@types/json-schema@npm:7.0.15"
   checksum: 10c0/a996a745e6c5d60292f36731dd41341339d4eeed8180bb09226e5c8d23759067692b1d88e5d91d72ee83dfc00d3aca8e7bd43ea120516c17922cbcb7c3e252db
+  languageName: node
+  linkType: hard
+
+"@types/micromatch@npm:^4.0.9":
+  version: 4.0.9
+  resolution: "@types/micromatch@npm:4.0.9"
+  dependencies:
+    "@types/braces": "npm:*"
+  checksum: 10c0/b13d7594b4320f20729f20156c51e957d79deb15083f98a736689cd0d3e4ba83b5d125959f6edf65270a6b6db90db9cebef8168d88e1c4eedc9a18aecc0234a3
   languageName: node
   linkType: hard
 
@@ -1484,7 +1500,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"braces@npm:^3.0.2":
+"braces@npm:^3.0.2, braces@npm:^3.0.3":
   version: 3.0.3
   resolution: "braces@npm:3.0.3"
   dependencies:
@@ -1939,6 +1955,7 @@ __metadata:
   dependencies:
     "@types/eslint": "npm:^8.40.2"
     "@types/jest": "npm:^29.5.13"
+    "@types/micromatch": "npm:^4.0.9"
     "@types/node": "npm:^20.3.3"
     "@typescript-eslint/parser": "npm:^8.0.0"
     "@typescript-eslint/rule-tester": "npm:^8.0.0"
@@ -1948,6 +1965,7 @@ __metadata:
     husky: "npm:^8.0.3"
     jest: "npm:^29.5.0"
     lint-staged: "npm:^14.0.0"
+    micromatch: "npm:^4.0.0"
     prettier: "npm:3.3.3"
     ts-jest: "npm:^29.1.1"
     ts-node: "npm:^10.9.1"
@@ -3472,6 +3490,16 @@ __metadata:
     braces: "npm:^3.0.2"
     picomatch: "npm:^2.3.1"
   checksum: 10c0/3d6505b20f9fa804af5d8c596cb1c5e475b9b0cd05f652c5b56141cf941bd72adaeb7a436fda344235cef93a7f29b7472efc779fcdb83b478eab0867b95cdeff
+  languageName: node
+  linkType: hard
+
+"micromatch@npm:^4.0.0":
+  version: 4.0.8
+  resolution: "micromatch@npm:4.0.8"
+  dependencies:
+    braces: "npm:^3.0.3"
+    picomatch: "npm:^2.3.1"
+  checksum: 10c0/166fa6eb926b9553f32ef81f5f531d27b4ce7da60e5baf8c021d043b27a388fb95e46a8038d5045877881e673f8134122b59624d5cecbd16eb50a42e7a6b5ca8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PRs brings patterns for `ignoreFunction` option. 

## Breaking changes

Behavior of `ignoreFunction` is changed.  Strings passed to this options are matched using `micromatch` against full callee path (`ctx.myNode.addEventListener`). You need to update your options accordingly. 

Example:

Previously: 

```js
// { "ignoreFunction": ["addEventListener"] }
myNode.addEventListener() //  ✅ match
addEventListener() //  ✅ match
ctx.myNode.addEventListener() // ❌ not match
```

Now:

```js
// { "ignoreFunction": ["*.addEventListener"] }
myNode.addEventListener() //  ✅ match
addEventListener() //  ❌ not match
ctx.myNode.addEventListener() // ✅ match
```

`addEventListener`  (without `*.`) will match only `addEventListener()` 
```js
// { "ignoreFunction": ["addEventListener"] }
addEventListener() //  ✅ match
myNode.addEventListener() //  ❌ not match
ctx.myNode.addEventListener() // ❌ not match
```