### PR TITLE
feat(no-unlocalized-strings): remove default configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ yarn add eslint-plugin-lingui --dev
 
 ### Recommended Setup
 
-To enable all of the recommended rules for our plugin, add the following config:
+To enable all the recommended rules for our plugin, add the following config:
 
 ```js
 import pluginLingui from 'eslint-plugin-lingui'
@@ -46,6 +46,8 @@ export default [
   // Any other config...
 ]
 ```
+
+We also recommend enabling the [no-unlocalized-strings](docs/rules/no-unlocalized-strings.md) rule. It’s not enabled by default because it needs to be set up specifically for your project. Please check the rule's documentation for example configurations.
 
 ### Custom setup
 

--- a/docs/rules/no-unlocalized-strings.md
+++ b/docs/rules/no-unlocalized-strings.md
@@ -17,8 +17,6 @@ The rule doesn’t come with built-in ignore settings because each project is un
     {
       "useTsTypes": true,
       "ignore": [
-        // Ignore strings that do not contain words
-        "^[^A-Za-z]+$",
         // Ignore strings that don’t start with an uppercase letter
         //   or don't contain two words separated by whitespace
         "^(?![A-Z].*|\\w+\\s\\w+).+$",

--- a/docs/rules/no-unlocalized-strings.md
+++ b/docs/rules/no-unlocalized-strings.md
@@ -5,17 +5,92 @@ Ensures that all string literals, templates, and JSX text are wrapped using `<Tr
 > [!IMPORTANT]  
 > This rule may require TypeScript type information. Enable this feature by setting `{ useTsTypes: true }`.
 
+This rule is designed to **match all** JSXText, StringLiterals, and TmplLiterals, and then exclude some of them based on attributes, property names, variable names, and so on.
+
+The rule doesn’t come with built-in ignore settings because each project is unique and needs different configurations. You can use the following config as a starting point and then adjust it for your project:
+
+<!-- prettier-ignore -->
+```json5
+{
+  "no-unlocalized-strings": [
+    "error",
+    {
+      "useTsTypes": true,
+      "ignore": [
+        // Ignore strings that do not contain words
+        "^[^A-Za-z]+$",
+        // Ignore strings that don’t start with an uppercase letter
+        //   or don't contain two words separated by whitespace
+        "^(?![A-Z].*|\\w+\\s\\w+).+$",
+        // Ignore UPPERCASE literals
+        // Example: const test = "FOO"
+        "^[A-Z_-]+$"
+      ],
+      "ignoreAttribute": [
+        // Ignore attributes matching className (case-insensitive)
+        { "regex": { "pattern": "className", "flags": "i" } },
+        "styleName",
+        "src",
+        "srcSet",
+        "type",
+        "id",
+        "width",
+        "height"
+      ],
+      "ignoreProperty": [
+        // Ignore properties matching className (case-insensitive)
+        { "regex": { "pattern": "className", "flags": "i" } },
+        "styleName",
+        "type",
+        "id",
+        "width",
+        "height",
+        "displayName",
+        "Authorization",
+        // Ignore UPPERCASE properties
+        // Example: test.FOO = "ola!"
+        { "regex": { "pattern": "^[A-Z_-]+$" } }
+      ],
+      "ignoreFunction": [
+        "cva",
+        "cn",
+        "track",
+        "Error",
+        "console.*",
+        "*headers.set",
+        "*.addEventListener",
+        "*.removeEventListener",
+        "*.postMessage",
+        "*.getElementById",
+        "*.dispatch",
+        "*.commit",
+        "*.includes",
+        "*.indexOf",
+        "*.endsWith",
+        "*.startsWith",
+        "require"
+      ],
+      "ignoreVariable": [
+        // Ignore literals assigned to variables with UPPERCASE names
+        // Example: const FOO = "Ola!"
+        { "regex": { "pattern": "^[A-Z_-]+$" } }
+      ],
+      "ignoreMethodsOnType": [
+        // Ignore specified methods on Map and Set types
+        "Map.get",
+        "Map.has",
+        "Set.has"
+      ]
+    }
+  ]
+}
+```
+
 ## Options
 
 ### `useTsTypes`
 
 Enables the rule to use TypeScript type information. Requires [typed linting](https://typescript-eslint.io/getting-started/typed-linting/) to be configured.
-
-This option automatically excludes built-in methods such as `Map` and `Set`, and cases where string literals are used as TypeScript constants, e.g.:
-
-```ts
-const a: 'abc' = 'abc'
-```
 
 ### `ignore`
 
@@ -77,7 +152,7 @@ foo[getName()].set('Hello')
 
 ### `ignoreAttribute`
 
-Specifies JSX attributes that should be ignored. By default, the attributes `className`, `styleName`, `type`, `id`, `width`, and `height` are ignored.
+Specifies JSX attributes that should be ignored.
 
 Example for `{ "ignoreAttribute": ["style"] }`:
 
@@ -158,16 +233,16 @@ const element = <div description="IMAGE" />
 
 ### `ignoreProperty`
 
-Specifies object property names whose values should be ignored. By default, UPPERCASED properties and `className`, `styleName`, `type`, `id`, `width`, `height`, and `displayName` are ignored.
+Specifies object property names whose values should be ignored.
 
-Example for `{ "ignoreProperty": ["myProperty"] }`:
+Example for `{ "ignoreProperty": ["displayName"] }`:
 
 ```jsx
-const obj = { myProperty: 'Ignored value' }
-obj.myProperty = 'Ignored value'
+const obj = { displayName: 'Ignored value' }
+obj.displayName = 'Ignored value'
 
 class MyClass {
-  myProperty = 'Ignored value'
+  displayName = 'Ignored value'
 }
 ```
 
@@ -208,7 +283,7 @@ class MyClass {
 
 ### `ignoreVariable`
 
-Specifies variable name whose values should be ignored. By default, UPPERCASED variables are ignored.
+Specifies variable name whose values should be ignored.
 
 Example for `{ "ignoreVariable": ["myVariable"] }`:
 
@@ -264,5 +339,3 @@ interface Foo {
 const foo: Foo
 foo.get('Some string')
 ```
-
-The following methods are ignored by default: `Map.get`, `Map.has`, `Set.has`.

--- a/docs/rules/no-unlocalized-strings.md
+++ b/docs/rules/no-unlocalized-strings.md
@@ -202,46 +202,6 @@ class MyClass {
 }
 ```
 
-### `strictAttribute`
-
-Specifies JSX attributes that should always be checked, regardless of other `ignore` settings or defaults.
-
-Example for `{ "strictAttribute": ["alt"] }`:
-
-```jsx
-/*eslint lingui/no-unlocalized-strings: ["error", {"strictAttribute": ["alt"]}]*/
-const element = <img alt="IMAGE" />
-```
-
-#### `regex`
-
-Defines regex patterns for attributes that must always be checked.
-
-Example:
-
-```json
-{
-  "no-unlocalized-strings": [
-    "error",
-    {
-      "strictAttribute": [
-        {
-          "regex": {
-            "pattern": "^desc.*"
-          }
-        }
-      ]
-    }
-  ]
-}
-```
-
-Examples of **incorrect** code:
-
-```jsx
-const element = <div description="IMAGE" />
-```
-
 ### `ignoreMethodsOnTypes`
 
 Uses TypeScript type information to ignore methods defined on specific types.

--- a/docs/rules/no-unlocalized-strings.md
+++ b/docs/rules/no-unlocalized-strings.md
@@ -22,7 +22,7 @@ The rule doesn’t come with built-in ignore settings because each project is un
         "^(?![A-Z].*|\\w+\\s\\w+).+$",
         // Ignore UPPERCASE literals
         // Example: const test = "FOO"
-        "^[A-Z_-]+$"
+        "^[A-Z0-9_-]+$"
       ],
       "ignoreAttribute": [
         // Ignore attributes matching className (case-insensitive)
@@ -47,7 +47,7 @@ The rule doesn’t come with built-in ignore settings because each project is un
         "Authorization",
         // Ignore UPPERCASE properties
         // Example: test.FOO = "ola!"
-        { "regex": { "pattern": "^[A-Z_-]+$" } }
+        { "regex": { "pattern": "^[A-Z0-9_-]+$" } }
       ],
       "ignoreFunction": [
         "cva",
@@ -71,7 +71,7 @@ The rule doesn’t come with built-in ignore settings because each project is un
       "ignoreVariable": [
         // Ignore literals assigned to variables with UPPERCASE names
         // Example: const FOO = "Ola!"
-        { "regex": { "pattern": "^[A-Z_-]+$" } }
+        { "regex": { "pattern": "^[A-Z0-9_-]+$" } }
       ],
       "ignoreMethodsOnType": [
         // Ignore specified methods on Map and Set types

--- a/docs/rules/no-unlocalized-strings.md
+++ b/docs/rules/no-unlocalized-strings.md
@@ -15,7 +15,6 @@ The rule doesn’t come with built-in ignore settings because each project is un
   "no-unlocalized-strings": [
     "error",
     {
-      "useTsTypes": true,
       "ignore": [
         // Ignore strings that don’t start with an uppercase letter
         //   or don't contain two words separated by whitespace
@@ -24,32 +23,23 @@ The rule doesn’t come with built-in ignore settings because each project is un
         // Example: const test = "FOO"
         "^[A-Z0-9_-]+$"
       ],
-      "ignoreAttribute": [
-        // Ignore attributes matching className (case-insensitive)
+      "ignoreNames": [
+        // Ignore matching className (case-insensitive)
         { "regex": { "pattern": "className", "flags": "i" } },
+        // Ignore UPPERCASE names
+        // Example: test.FOO = "ola!"
+        { "regex": { "pattern": "^[A-Z0-9_-]+$" } },
         "styleName",
         "src",
         "srcSet",
         "type",
         "id",
         "width",
-        "height"
-      ],
-      "ignoreProperty": [
-        // Ignore properties matching className (case-insensitive)
-        { "regex": { "pattern": "className", "flags": "i" } },
-        "styleName",
-        "type",
-        "id",
-        "width",
         "height",
         "displayName",
-        "Authorization",
-        // Ignore UPPERCASE properties
-        // Example: test.FOO = "ola!"
-        { "regex": { "pattern": "^[A-Z0-9_-]+$" } }
+        "Authorization"
       ],
-      "ignoreFunction": [
+      "ignoreFunctions": [
         "cva",
         "cn",
         "track",
@@ -68,11 +58,8 @@ The rule doesn’t come with built-in ignore settings because each project is un
         "*.startsWith",
         "require"
       ],
-      "ignoreVariable": [
-        // Ignore literals assigned to variables with UPPERCASE names
-        // Example: const FOO = "Ola!"
-        { "regex": { "pattern": "^[A-Z0-9_-]+$" } }
-      ],
+      // Following settings require typed linting https://typescript-eslint.io/getting-started/typed-linting/
+      "useTsTypes": true,
       "ignoreMethodsOnType": [
         // Ignore specified methods on Map and Set types
         "Map.get",
@@ -101,17 +88,17 @@ Example for `{ "ignore": ["rgba"] }`:
 const color = <div style={{ color: 'rgba(100, 100, 100, 0.4)' }} />
 ```
 
-### `ignoreFunction`
+### `ignoreFunctions`
 
 Specifies functions whose string arguments should be ignored.
 
 Example of `correct` code with this option:
 
 ```js
-/*eslint lingui/no-unlocalized-strings: ["error", {"ignoreFunction": ["showIntercomMessage"]}]*/
+/*eslint lingui/no-unlocalized-strings: ["error", {"ignoreFunctions": ["showIntercomMessage"]}]*/
 showIntercomMessage('Please write me')
 
-/*eslint lingui/no-unlocalized-strings: ["error", { "ignoreFunction": ["cva"] }]*/
+/*eslint lingui/no-unlocalized-strings: ["error", { "ignoreFunctions": ["cva"] }]*/
 const labelVariants = cva('text-form-input-content-helper', {
   variants: {
     size: {
@@ -122,46 +109,60 @@ const labelVariants = cva('text-form-input-content-helper', {
 })
 ```
 
-This option also supports member expressions. Example for `{ "ignoreFunction": ["console.log"] }`:
+This option also supports member expressions. Example for `{ "ignoreFunctions": ["console.log"] }`:
 
 ```js
-/*eslint lingui/no-unlocalized-strings: ["error", {"ignoreFunction": ["console.log"]}]*/
+/*eslint lingui/no-unlocalized-strings: ["error", {"ignoreFunctions": ["console.log"]}]*/
 console.log('Log this message')
 ```
 
 You can use patterns (processed by [micromatch](https://www.npmjs.com/package/micromatch)) to match function calls.
 
 ```js
-/*eslint lingui/no-unlocalized-strings: ["error", {"ignoreFunction": ["console.*"]}]*/
+/*eslint lingui/no-unlocalized-strings: ["error", {"ignoreFunctions": ["console.*"]}]*/
 console.log('Log this message')
 ```
 
 ```js
-/*eslint lingui/no-unlocalized-strings: ["error", {"ignoreFunction": ["*.headers.set"]}]*/
+/*eslint lingui/no-unlocalized-strings: ["error", {"ignoreFunctions": ["*.headers.set"]}]*/
 context.headers.set('Authorization', `Bearer ${token}`)
 ```
 
 Dynamic segments are replaced with `$`, you can target them as
 
 ```js
-/*eslint lingui/no-unlocalized-strings: ["error", {"ignoreFunction": ["foo.$.set"]}]*/
+/*eslint lingui/no-unlocalized-strings: ["error", {"ignoreFunctions": ["foo.$.set"]}]*/
 foo[getName()].set('Hello')
 ```
 
-### `ignoreAttribute`
+### `ignoreNames`
 
-Specifies JSX attributes that should be ignored.
+List of identifier names to ignore across attributes, properties, and variables. Use this option to exclude specific names, like "className", from being flagged by the rule. This option covers any of these contexts: JSX attribute names, variable names, or property names.
 
-Example for `{ "ignoreAttribute": ["style"] }`:
+Example for `{ "ignoreNames": ["style"] }`:
+
+Example of `correct` code with this option:
 
 ```jsx
-/*eslint lingui/no-unlocalized-strings: ["error", {"ignoreAttribute": ["style"]}]*/
+/* eslint lingui/no-unlocalized-strings: ["error", {"ignoreNames": ["style"]}] */
+// ignored by JSX sttribute name
 const element = <div style={{ margin: '1rem 2rem' }} />
+// ignored by variable name
+const style = 'Ignored value!'
+
+/* eslint lingui/no-unlocalized-strings: ["error", {"ignoreNames": ["displayName"]}] */
+// ignored by property name
+const obj = { displayName: 'Ignored value' }
+obj.displayName = 'Ignored value'
+
+class MyClass {
+  displayName = 'Ignored value'
+}
 ```
 
 #### `regex`
 
-Defines regex patterns for ignored attributes.
+Defines regex patterns for ignored names.
 
 Example:
 
@@ -170,7 +171,7 @@ Example:
   "no-unlocalized-strings": [
     "error",
     {
-      "ignoreAttribute": [
+      "ignoreNames": [
         {
           "regex": {
             "pattern": "classname",
@@ -186,7 +187,19 @@ Example:
 Example of **correct** code:
 
 ```jsx
+// ignored by JSX attribute name
 const element = <div wrapperClassName="absolute top-1/2 left-1/2" />
+
+// ignored by variable name
+const wrapperClassName = 'Ignored value'
+
+// ignored by property name
+const obj = { wrapperClassName: 'Ignored value' }
+obj.wrapperClassName = 'Ignored value'
+
+class MyClass {
+  wrapperClassName = 'Ignored value'
+}
 ```
 
 ### `strictAttribute`
@@ -227,96 +240,6 @@ Examples of **incorrect** code:
 
 ```jsx
 const element = <div description="IMAGE" />
-```
-
-### `ignoreProperty`
-
-Specifies object property names whose values should be ignored.
-
-Example for `{ "ignoreProperty": ["displayName"] }`:
-
-```jsx
-const obj = { displayName: 'Ignored value' }
-obj.displayName = 'Ignored value'
-
-class MyClass {
-  displayName = 'Ignored value'
-}
-```
-
-#### `regex`
-
-Defines regex patterns for ignored properties.
-
-Example:
-
-```json
-{
-  "no-unlocalized-strings": [
-    "error",
-    {
-      "ignoreProperty": [
-        {
-          "regex": {
-            "pattern": "classname",
-            "flags": "i"
-          }
-        }
-      ]
-    }
-  ]
-}
-```
-
-Examples of **correct** code:
-
-```jsx
-const obj = { wrapperClassName: 'Ignored value' }
-obj.wrapperClassName = 'Ignored value'
-
-class MyClass {
-  wrapperClassName = 'Ignored value'
-}
-```
-
-### `ignoreVariable`
-
-Specifies variable name whose values should be ignored.
-
-Example for `{ "ignoreVariable": ["myVariable"] }`:
-
-```jsx
-const myVariable = 'Ignored value'
-```
-
-#### `regex`
-
-Defines regex patterns for ignored variables.
-
-Example:
-
-```json
-{
-  "no-unlocalized-strings": [
-    "error",
-    {
-      "ignoreVariable": [
-        {
-          "regex": {
-            "pattern": "classname",
-            "flags": "i"
-          }
-        }
-      ]
-    }
-  ]
-}
-```
-
-Examples of **correct** code:
-
-```jsx
-const wrapperClassName = 'Ignored value'
 ```
 
 ### `ignoreMethodsOnTypes`

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -29,8 +29,6 @@ export const LinguiCallExpressionMessageQuery =
  */
 export const LinguiTransQuery = 'JSXElement[openingElement.name.name=Trans]'
 
-export const UpperCaseRegexp = /^[A-Z_-]+$/
-
 export function isNativeDOMTag(str: string) {
   return DOM_TAGS.includes(str)
 }
@@ -39,27 +37,13 @@ export function isSvgTag(str: string) {
   return SVG_TAGS.includes(str)
 }
 
-export function containAllAttributes(attributeNames: string[]) {
-  const attrs = ['value', 'other']
-  return attrs.every((attr) => attributeNames.includes(attr))
-}
-
-export function isLinguiTags(str: string, attributeNames: string[]) {
-  if (str === 'Trans') {
-    return true
-  }
-  return ['Plural', 'Select'].includes(str) && containAllAttributes(attributeNames)
-}
-
 const blacklistAttrs = ['placeholder', 'alt', 'aria-label', 'value']
 export function isAllowedDOMAttr(tag: string, attr: string, attributeNames: string[]) {
   if (isSvgTag(tag)) return true
   if (isNativeDOMTag(tag)) {
     return !blacklistAttrs.includes(attr)
   }
-  if (isLinguiTags(tag, attributeNames)) {
-    return true
-  }
+
   return false
 }
 
@@ -85,26 +69,6 @@ export const getText = (
   }
 
   return node.value.toString().trim()
-}
-
-export function hasAncestorWithName(
-  node: TSESTree.JSXElement | TSESTree.TemplateLiteral | TSESTree.Literal | TSESTree.JSXText,
-  name: string,
-) {
-  let p: TSESTree.Node = node.parent
-  while (p) {
-    switch (p.type) {
-      case TSESTree.AST_NODE_TYPES.JSXElement:
-        const identifierName = getIdentifierName(p?.openingElement?.name)
-        if (identifierName === name) {
-          return true
-        }
-      default:
-    }
-
-    p = p.parent
-  }
-  return false
 }
 
 export function getIdentifierName(jsxTagNameExpression: TSESTree.JSXTagNameExpression) {

--- a/src/rules/no-unlocalized-strings.ts
+++ b/src/rules/no-unlocalized-strings.ts
@@ -25,7 +25,6 @@ export type Option = {
   ignore?: string[]
   ignoreFunctions?: string[]
   ignoreNames?: MatcherDef[]
-  strictAttribute?: MatcherDef[]
   ignoreMethodsOnTypes?: string[]
   useTsTypes?: boolean
 }
@@ -114,10 +113,6 @@ export const rule = createRule<Option[], string>({
             items: {
               type: 'string',
             },
-          },
-          strictAttribute: {
-            type: 'array',
-            items: MatcherSchema,
           },
           useTsTypes: {
             type: 'boolean',
@@ -221,7 +216,6 @@ export const rule = createRule<Option[], string>({
     }
 
     const isIgnoredName = createMatcher(option?.ignoreNames || [])
-    const isStrictAttribute = createMatcher(option?.strictAttribute || [])
 
     function isStringLiteral(node: TSESTree.Literal | TSESTree.TemplateLiteral | TSESTree.JSXText) {
       switch (node.type) {
@@ -305,12 +299,6 @@ export const rule = createRule<Option[], string>({
           TSESTree.AST_NODE_TYPES.JSXAttribute,
         )
         const attrName = getAttrName(parent?.name?.name)
-
-        if (isStrictAttribute(attrName)) {
-          visited.add(node)
-          context.report({ node, messageId: 'default' })
-          return
-        }
 
         // allow <MyComponent className="active" />
         if (isIgnoredName(attrName)) {

--- a/src/rules/no-unlocalized-strings.ts
+++ b/src/rules/no-unlocalized-strings.ts
@@ -150,7 +150,11 @@ export const rule = createRule<Option[], string>({
     if (option?.useTsTypes) {
       tsService = ESLintUtils.getParserServices(context, false)
     }
-    const whitelists = (option?.ignore || []).map((item) => new RegExp(item))
+    const whitelists = [
+      //
+      /^[^\p{L}]+$/u, // ignore non word messages
+      ...(option?.ignore || []).map((item) => new RegExp(item)),
+    ]
 
     const calleeWhitelists = [
       // lingui callee

--- a/tests/src/rules/no-unlocalized-strings.test.ts
+++ b/tests/src/rules/no-unlocalized-strings.test.ts
@@ -304,12 +304,6 @@ ruleTester.run<string, Option[]>(name, rule, {
       code: 'class Form extends Component { property = "Something" };',
       errors,
     },
-    { code: '<img alt="BLA" />', options: [{ strictAttribute: ['alt'] }], errors },
-    {
-      code: '<img altAaa="BLA" />',
-      options: [{ strictAttribute: [{ regex: { pattern: '^alt' } }] }],
-      errors,
-    },
     { code: '<div>foo</div>', errors: [{ messageId: 'forJsxText' }] },
     { code: '<div>Foo</div>', errors: [{ messageId: 'forJsxText' }] },
     { code: '<div>FOO</div>', errors: [{ messageId: 'forJsxText' }] },

--- a/tests/src/rules/no-unlocalized-strings.test.ts
+++ b/tests/src/rules/no-unlocalized-strings.test.ts
@@ -17,8 +17,7 @@ const ruleTester = new RuleTester({
 })
 
 const upperCaseRegex = '^[A-Z_-]+$'
-const ignoreUpperCaseVariable = { ignoreVariable: [{ regex: { pattern: upperCaseRegex } }] }
-const ignoreUpperCaseProperty = { ignoreProperty: [{ regex: { pattern: upperCaseRegex } }] }
+const ignoreUpperCaseName = { ignoreNames: [{ regex: { pattern: upperCaseRegex } }] }
 
 const errors = [{ messageId: 'default' }] // default errors
 
@@ -38,40 +37,40 @@ ruleTester.run<string, Option[]>(name, rule, {
     },
     {
       code: 'hello("Hello")',
-      options: [{ ignoreFunction: ['hello'] }],
+      options: [{ ignoreFunctions: ['hello'] }],
     },
     {
       code: 'new Error("hello")',
-      options: [{ ignoreFunction: ['Error'] }],
+      options: [{ ignoreFunctions: ['Error'] }],
     },
     {
       code: 'custom.wrapper()({message: "Hello!"})',
-      options: [{ ignoreFunction: ['custom.wrapper'] }],
+      options: [{ ignoreFunctions: ['custom.wrapper'] }],
     },
     {
       name: 'Should ignore calls using complex object.method expression',
       code: 'console.log("Hello")',
-      options: [{ ignoreFunction: ['console.log'] }],
+      options: [{ ignoreFunctions: ['console.log'] }],
     },
     {
       name: 'Should ignore method calls using pattern',
       code: 'console.log("Hello"); console.error("Hello");',
-      options: [{ ignoreFunction: ['console.*'] }],
+      options: [{ ignoreFunctions: ['console.*'] }],
     },
     {
       name: 'Should ignore methods multilevel',
       code: 'context.headers.set("Hello"); level.context.headers.set("Hello");',
-      options: [{ ignoreFunction: ['*.headers.set'] }],
+      options: [{ ignoreFunctions: ['*.headers.set'] }],
     },
     {
       name: 'Should ignore methods multilevel 2',
       code: 'headers.set("Hello"); level.context.headers.set("Hello");',
-      options: [{ ignoreFunction: ['*headers.set'] }],
+      options: [{ ignoreFunctions: ['*headers.set'] }],
     },
     {
       name: 'Should ignore methods with dynamic segment ',
       code: 'getData().two.three.four("Hello")',
-      options: [{ ignoreFunction: ['*.three.four'] }],
+      options: [{ ignoreFunctions: ['*.three.four'] }],
     },
     { code: 'name === `Hello brat` || name === `Nice have`' },
     { code: 'switch(a){ case `a`: break; default: break;}' },
@@ -83,8 +82,8 @@ ruleTester.run<string, Option[]>(name, rule, {
     { code: 'import name from "hello";' },
     { code: 'export * from "hello_export_all";' },
     { code: 'export { a } from "hello_export";' },
-    { code: 'const a = require(["hello"]);', options: [{ ignoreFunction: ['require'] }] },
-    { code: 'const a = require(["hel" + "lo"]);', options: [{ ignoreFunction: ['require'] }] },
+    { code: 'const a = require(["hello"]);', options: [{ ignoreFunctions: ['require'] }] },
+    { code: 'const a = require(["hel" + "lo"]);', options: [{ ignoreFunctions: ['require'] }] },
     { code: 'const a = 1;' },
     { code: 'i18n._("hello");' },
     { code: 'const a = "absfoo";', options: [{ ignore: ['foo'] }] },
@@ -126,11 +125,11 @@ ruleTester.run<string, Option[]>(name, rule, {
     { code: '<img src={`./image.png`} />' },
     { code: '<button type="button" for="form-id" />' },
     { code: '<button type={`button`} for={`form-id`} />' },
-    { code: '<DIV foo="bar" />', options: [{ ignoreAttribute: ['foo'] }] },
-    { code: '<DIV foo={`Bar`} />', options: [{ ignoreAttribute: ['foo'] }] },
+    { code: '<DIV foo="bar" />', options: [{ ignoreNames: ['foo'] }] },
+    { code: '<DIV foo={`Bar`} />', options: [{ ignoreNames: ['foo'] }] },
     {
       code: '<DIV wrapperClassName={`Bar`} />',
-      options: [{ ignoreAttribute: [{ regex: { pattern: 'className', flags: 'i' } }] }],
+      options: [{ ignoreNames: [{ regex: { pattern: 'className', flags: 'i' } }] }],
     },
     { code: '<div>&nbsp; </div>' },
     { code: "plural('Hello')" },
@@ -142,7 +141,7 @@ ruleTester.run<string, Option[]>(name, rule, {
           {...restProps}
           autoComplete="off"
       />`,
-      options: [{ ignoreAttribute: ['autoComplete'] }],
+      options: [{ ignoreNames: ['autoComplete'] }],
     },
     {
       code: 'const Wrapper = styled.a` cursor: pointer; ${(props) => props.isVisible && `visibility: visible;`}`',
@@ -152,27 +151,27 @@ ruleTester.run<string, Option[]>(name, rule, {
     },
     {
       code: `const test = { myProp: 'This is not localized' }`,
-      options: [{ ignoreProperty: ['myProp'] }],
+      options: [{ ignoreNames: ['myProp'] }],
     },
     {
       code: 'const test = { myProp: `This is not localized` }',
-      options: [{ ignoreProperty: ['myProp'] }],
+      options: [{ ignoreNames: ['myProp'] }],
     },
     {
       code: `const test = { ['myProp']: 'This is not localized' }`,
-      options: [{ ignoreProperty: ['myProp'] }],
+      options: [{ ignoreNames: ['myProp'] }],
     },
     {
       code: `const test = { wrapperClassName: 'This is not localized' }`,
-      options: [{ ignoreProperty: [{ regex: { pattern: 'className', flags: 'i' } }] }],
+      options: [{ ignoreNames: [{ regex: { pattern: 'className', flags: 'i' } }] }],
     },
     {
       code: `MyComponent.displayName = 'MyComponent';`,
-      options: [{ ignoreProperty: ['displayName'] }],
+      options: [{ ignoreNames: ['displayName'] }],
     },
     {
       code: 'class Form extends Component { displayName = "FormContainer" };',
-      options: [{ ignoreProperty: ['displayName'] }],
+      options: [{ ignoreNames: ['displayName'] }],
     },
     {
       name: 'computed keys should be ignored by default, StringLiteral',
@@ -184,39 +183,38 @@ ruleTester.run<string, Option[]>(name, rule, {
     },
     {
       code: `const test = "Hello!"`,
-      options: [{ ignoreVariable: ['test'] }],
+      options: [{ ignoreNames: ['test'] }],
     },
     {
       code: `let test = "Hello!"`,
-      options: [{ ignoreVariable: ['test'] }],
+      options: [{ ignoreNames: ['test'] }],
     },
     {
       code: `var test = "Hello!"`,
-      options: [{ ignoreVariable: ['test'] }],
+      options: [{ ignoreNames: ['test'] }],
     },
     {
       code: 'const test = `Hello!`',
-      options: [{ ignoreVariable: ['test'] }],
+      options: [{ ignoreNames: ['test'] }],
     },
-
     {
       code: `const wrapperClassName  = "Hello!"`,
-      options: [{ ignoreVariable: [{ regex: { pattern: 'className', flags: 'i' } }] }],
+      options: [{ ignoreNames: [{ regex: { pattern: 'className', flags: 'i' } }] }],
     },
     {
       code: `const A_B  = "Bar!"`,
-      options: [ignoreUpperCaseVariable],
+      options: [ignoreUpperCaseName],
     },
     {
       code: 'const FOO  = `Bar!`',
-      options: [ignoreUpperCaseVariable],
+      options: [ignoreUpperCaseName],
     },
-    { code: 'var a = {["A_B"]: "hello world"};', options: [ignoreUpperCaseProperty] },
-    { code: 'var a = {[A_B]: "hello world"};', options: [ignoreUpperCaseProperty] },
-    { code: 'var a = {A_B: "hello world"};', options: [ignoreUpperCaseProperty] },
-    { code: 'var a = {[`A_B`]: `hello world`};', options: [ignoreUpperCaseProperty] },
-    { code: 'var a = {[A_B]: `hello world`};', options: [ignoreUpperCaseProperty] },
-    { code: 'var a = {A_B: `hello world`};', options: [ignoreUpperCaseProperty] },
+    { code: 'var a = {["A_B"]: "hello world"};', options: [ignoreUpperCaseName] },
+    { code: 'var a = {[A_B]: "hello world"};', options: [ignoreUpperCaseName] },
+    { code: 'var a = {A_B: "hello world"};', options: [ignoreUpperCaseName] },
+    { code: 'var a = {[`A_B`]: `hello world`};', options: [ignoreUpperCaseName] },
+    { code: 'var a = {[A_B]: `hello world`};', options: [ignoreUpperCaseName] },
+    { code: 'var a = {A_B: `hello world`};', options: [ignoreUpperCaseName] },
 
     { code: '<div className="hello"></div>', filename: 'a.tsx' },
     { code: '<div className={`hello`}></div>', filename: 'a.tsx' },

--- a/tests/src/rules/no-unlocalized-strings.test.ts
+++ b/tests/src/rules/no-unlocalized-strings.test.ts
@@ -29,6 +29,14 @@ ruleTester.run<string, Option[]>(name, rule, {
     },
     { code: 't(i18n)({ message: `Hello ${name}` })' },
     {
+      name: 'should ignore non word strings',
+      code: 'const test = "1111"',
+    },
+    {
+      name: 'should ignore non word strings 2',
+      code: 'const a = `0123456789!@#$%^&*()_+|~-=\\`[]{};\':",./<>?`;',
+    },
+    {
       code: 'hello("Hello")',
       options: [{ ignoreFunction: ['hello'] }],
     },
@@ -257,6 +265,21 @@ ruleTester.run<string, Option[]>(name, rule, {
     { code: 'const a = `Foo`;', errors },
     { code: 'const a = call(`Ffo`);', errors },
     { code: 'var a = {foo: `Bar`};', errors },
+    {
+      name: 'Should report non latin messages (japanese)',
+      code: 'const a = "こんにちは"',
+      errors,
+    },
+    {
+      name: 'Should report non latin messages (cyrillic)',
+      code: 'const a = "Привет"',
+      errors,
+    },
+    {
+      name: 'Should report non latin messages (chinese)',
+      code: 'const a = "添加筛选器"',
+      errors,
+    },
     { code: 'const a = `a foo`;', options: [{ ignore: ['^foo'] }], errors },
     {
       code: 'class Form extends Component { property = `Something` };',

--- a/tests/src/rules/no-unlocalized-strings.test.ts
+++ b/tests/src/rules/no-unlocalized-strings.test.ts
@@ -16,6 +16,10 @@ const ruleTester = new RuleTester({
   },
 })
 
+const upperCaseRegex = '^[A-Z_-]+$'
+const ignoreUpperCaseVariable = { ignoreVariable: [{ regex: { pattern: upperCaseRegex } }] }
+const ignoreUpperCaseProperty = { ignoreProperty: [{ regex: { pattern: upperCaseRegex } }] }
+
 const errors = [{ messageId: 'default' }] // default errors
 
 ruleTester.run<string, Option[]>(name, rule, {
@@ -24,6 +28,14 @@ ruleTester.run<string, Option[]>(name, rule, {
       code: 'i18n._(t`Hello ${nice}`)',
     },
     { code: 't(i18n)({ message: `Hello ${name}` })' },
+    {
+      code: 'hello("Hello")',
+      options: [{ ignoreFunction: ['hello'] }],
+    },
+    {
+      code: 'new Error("hello")',
+      options: [{ ignoreFunction: ['Error'] }],
+    },
     {
       code: 'custom.wrapper()({message: "Hello!"})',
       options: [{ ignoreFunction: ['custom.wrapper'] }],
@@ -44,77 +56,32 @@ ruleTester.run<string, Option[]>(name, rule, {
       options: [{ ignoreFunction: ['*.headers.set'] }],
     },
     {
+      name: 'Should ignore methods multilevel 2',
+      code: 'headers.set("Hello"); level.context.headers.set("Hello");',
+      options: [{ ignoreFunction: ['*headers.set'] }],
+    },
+    {
       name: 'Should ignore methods with dynamic segment ',
       code: 'getData().two.three.four("Hello")',
       options: [{ ignoreFunction: ['*.three.four'] }],
     },
     { code: 'name === `Hello brat` || name === `Nice have`' },
     { code: 'switch(a){ case `a`: break; default: break;}' },
-    { code: 'a.indexOf(`ios`)' },
-    { code: 'a.includes(`ios`)' },
-    { code: 'a.startsWith(`ios`)' },
-    { code: 'a.endsWith(`@gmail.com`)' },
-    {
-      code: 'document.addEventListener(`click`, (event) => { event.preventDefault() })',
-    },
-    {
-      code: 'document.removeEventListener(`click`, (event) => { event.preventDefault() })',
-    },
-    { code: 'window.postMessage(`message`, `*`)' },
-    { code: 'document.getElementById(`some-id`)' },
-    { code: 'require(`hello`);' },
-    { code: 'const a = require([`hello`]);' },
-    { code: 'const a = require([`hel` + `lo`]);' },
-    { code: 'const a = `?`;' },
-    { code: 'const a = `0123456789!@#$%^&*()_+|~-=\\`[]{};\':",./<>?`;' },
     { code: 'i18n._(`hello`);' },
-    { code: 'dispatch(`hello`);' },
-    { code: 'store.dispatch(`hello`);' },
-    { code: 'store.commit(`hello`);' },
     { code: 'const a = `absfoo`;', options: [{ ignore: ['foo'] }] },
     { code: 'const a = `fooabc`;', options: [{ ignore: ['^foo'] }] },
-    { code: 'const a = `FOO`;' },
     { code: "name === 'Hello brat' || name === 'Nice have'" },
     { code: "switch(a){ case 'a': break; default: break;}" },
     { code: 'import name from "hello";' },
-    { code: 'a.indexOf("ios")' },
-    { code: 'a.includes("ios")' },
-    { code: 'a.startsWith("ios")' },
-    { code: 'a.endsWith("@gmail.com")' },
     { code: 'export * from "hello_export_all";' },
     { code: 'export { a } from "hello_export";' },
-    {
-      code: 'document.addEventListener("click", (event) => { event.preventDefault() })',
-    },
-    {
-      code: 'document.removeEventListener("click", (event) => { event.preventDefault() })',
-    },
-    { code: 'window.postMessage("message", "Ola!")' },
-    { code: 'document.getElementById("some-id")' },
-    { code: 'require("hello");' },
-    { code: 'const a = require(["hello"]);' },
-    { code: 'const a = require(["hel" + "lo"]);' },
+    { code: 'const a = require(["hello"]);', options: [{ ignoreFunction: ['require'] }] },
+    { code: 'const a = require(["hel" + "lo"]);', options: [{ ignoreFunction: ['require'] }] },
     { code: 'const a = 1;' },
-    { code: 'const a = "?";' },
-    { code: `const a = "0123456789!@#$%^&*()_+|~-=\`[]{};':\\",./<>?";` },
     { code: 'i18n._("hello");' },
-    { code: 'dispatch("hello");' },
-    { code: 'store.dispatch("hello");' },
-    { code: 'store.commit("hello");' },
     { code: 'const a = "absfoo";', options: [{ ignore: ['foo'] }] },
     { code: 'const a = "fooabc";', options: [{ ignore: ['^foo'] }] },
-    { code: 'const a = "FOO";' },
-    { code: 'var A_B = "world";' },
-    { code: 'var A_B = `world`;' },
-    { code: 'var a = {["A_B"]: "hello world"};' },
-    { code: 'var a = {[A_B]: "hello world"};' },
-    { code: 'var a = {A_B: "hello world"};' },
-    { code: 'var a = {foo: "FOO"};' },
-    { code: 'var a = {[`A_B`]: `hello world`};' },
-    { code: 'var a = {[A_B]: `hello world`};' },
-    { code: 'var a = {A_B: `hello world`};' },
-    { code: 'var a = {foo: `FOO`};' },
-    { code: 'class Form extends Component { displayName = "FormContainer" };' },
+
     //     // JSX
     { code: '<div className="primary"></div>' },
     { code: '<div className={`primary`}></div>' },
@@ -157,40 +124,17 @@ ruleTester.run<string, Option[]>(name, rule, {
       code: '<DIV wrapperClassName={`Bar`} />',
       options: [{ ignoreAttribute: [{ regex: { pattern: 'className', flags: 'i' } }] }],
     },
-    { code: '<DIV foo={`bar`} />' },
-    { code: '<DIV foo="bar" />' },
-    { code: 'a + `b`' },
-    {
-      code: 'switch(a){ case `a`: var a =`b`; break; default: break;}',
-    },
-    { code: 'var a = {foo: `bar`};' },
-    { code: '<img src="./image.png" alt="some-image" />' },
-    { code: 'var a = {foo: "bar"};' },
-    { code: 'const a = "foo";' },
-    { code: 'export const a = "hello_string";' },
-    { code: 'Error("hello")', options: [{ ignoreFunction: ['Error'] }] },
-    {
-      code: 'new Error("hello")',
-      options: [{ ignoreFunction: ['Error'] }],
-    },
-    {
-      code: 'hello("Hello")',
-      options: [{ ignoreFunction: ['hello'] }],
-    },
-    {
-      code: 'formatDate(date, "d LLL")',
-      options: [{ ignoreFunction: ['formatDate'] }],
-    },
     { code: '<div>&nbsp; </div>' },
-    { code: "plural('hello')" },
-    { code: "select('hello')" },
-    { code: "<Plural value='Hello' one='2' other='Hello' /> " },
-    { code: "<Select value='Hello' one='2' other='Hello' /> " },
+    { code: "plural('Hello')" },
+    { code: "select('Hello')" },
+    { code: "selectOrdinal('Hello')" },
+    { code: 'msg({message: `Hello!`})' },
     {
       code: `<Input
           {...restProps}
           autoComplete="off"
       />`,
+      options: [{ ignoreAttribute: ['autoComplete'] }],
     },
     {
       code: 'const Wrapper = styled.a` cursor: pointer; ${(props) => props.isVisible && `visibility: visible;`}`',
@@ -198,9 +142,12 @@ ruleTester.run<string, Option[]>(name, rule, {
     {
       code: "const Wrapper = styled.a` cursor: pointer; ${(props) => props.isVisible && 'visibility: visible;'}`",
     },
-    { code: `const test = { id: 'This is not localized' }` },
     {
       code: `const test = { myProp: 'This is not localized' }`,
+      options: [{ ignoreProperty: ['myProp'] }],
+    },
+    {
+      code: 'const test = { myProp: `This is not localized` }',
       options: [{ ignoreProperty: ['myProp'] }],
     },
     {
@@ -211,27 +158,98 @@ ruleTester.run<string, Option[]>(name, rule, {
       code: `const test = { wrapperClassName: 'This is not localized' }`,
       options: [{ ignoreProperty: [{ regex: { pattern: 'className', flags: 'i' } }] }],
     },
-    { code: `obj["key with space"] = 5` },
-    { code: `obj[\`key with space\`] = 5` },
-    { code: `const FOO = "Hello!"` },
-    { code: `let FOO = "Hello!"` },
-    { code: `var FOO = "Hello!"` },
-
+    {
+      code: `MyComponent.displayName = 'MyComponent';`,
+      options: [{ ignoreProperty: ['displayName'] }],
+    },
+    {
+      code: 'class Form extends Component { displayName = "FormContainer" };',
+      options: [{ ignoreProperty: ['displayName'] }],
+    },
+    {
+      name: 'computed keys should be ignored by default, StringLiteral',
+      code: `obj["key with space"] = 5`,
+    },
+    {
+      name: 'computed keys should be ignored by default with TplLiteral',
+      code: `obj[\`key with space\`] = 5`,
+    },
     {
       code: `const test = "Hello!"`,
       options: [{ ignoreVariable: ['test'] }],
     },
     {
+      code: `let test = "Hello!"`,
+      options: [{ ignoreVariable: ['test'] }],
+    },
+    {
+      code: `var test = "Hello!"`,
+      options: [{ ignoreVariable: ['test'] }],
+    },
+    {
+      code: 'const test = `Hello!`',
+      options: [{ ignoreVariable: ['test'] }],
+    },
+
+    {
       code: `const wrapperClassName  = "Hello!"`,
       options: [{ ignoreVariable: [{ regex: { pattern: 'className', flags: 'i' } }] }],
+    },
+    {
+      code: `const A_B  = "Bar!"`,
+      options: [ignoreUpperCaseVariable],
+    },
+    {
+      code: 'const FOO  = `Bar!`',
+      options: [ignoreUpperCaseVariable],
+    },
+    { code: 'var a = {["A_B"]: "hello world"};', options: [ignoreUpperCaseProperty] },
+    { code: 'var a = {[A_B]: "hello world"};', options: [ignoreUpperCaseProperty] },
+    { code: 'var a = {A_B: "hello world"};', options: [ignoreUpperCaseProperty] },
+    { code: 'var a = {[`A_B`]: `hello world`};', options: [ignoreUpperCaseProperty] },
+    { code: 'var a = {[A_B]: `hello world`};', options: [ignoreUpperCaseProperty] },
+    { code: 'var a = {A_B: `hello world`};', options: [ignoreUpperCaseProperty] },
+
+    { code: '<div className="hello"></div>', filename: 'a.tsx' },
+    { code: '<div className={`hello`}></div>', filename: 'a.tsx' },
+    { code: "var a: Element['nodeName']" },
+    { code: "var a: Omit<T, 'af'>" },
+    { code: `var a: 'abc' = 'abc'`, skip: true },
+    { code: `var a: 'abc' | 'name'  | undefined= 'abc'`, skip: true },
+    { code: "type T = {name: 'b'} ; var a: T =  {name: 'b'}", skip: true },
+    { code: "function Button({ t= 'name' }: {t: 'name'}){} ", skip: true },
+    { code: "type T = { t?: 'name'| 'abc'}; function Button({t='name'}:T){}", skip: true },
+    {
+      code: `enum StepType {
+        Address = 'Address'
+      }`,
+    },
+    {
+      code: `enum StepType {
+        Address = \`Address\`
+      }`,
+    },
+
+    {
+      code: `const myMap = new Map(); 
+      myMap.get("string with a spaces")
+      myMap.has("string with a spaces")`,
+      options: [{ useTsTypes: true, ignoreMethodsOnTypes: ['Map.get', 'Map.has'] }],
+    },
+    {
+      code: `interface Foo {get: (key: string) => string}; 
+      (foo as Foo).get("string with a spaces")`,
+      options: [{ useTsTypes: true, ignoreMethodsOnTypes: ['Foo.get'] }],
+    },
+    {
+      code: `interface Foo {get: (key: string) => string};
+      const foo: Foo;
+      foo.get("string with a spaces")`,
+      options: [{ useTsTypes: true, ignoreMethodsOnTypes: ['Foo.get'] }],
     },
   ],
 
   invalid: [
-    { code: "<Plural value='Hello' one='2' notOther='3' /> ", errors },
-    { code: "<Select value='Hello' one='2' notOther='3' /> ", errors },
-    { code: "<Plural notValue='Hello' one='2' other='3' /> ", errors },
-    { code: "<Select notValue='Hello' one='2' other='3' /> ", errors },
     { code: '<div>hello &nbsp; </div>', errors: [{ messageId: 'forJsxText' }] },
     { code: 'const a = `Hello ${nice}`', errors },
     { code: 'export const a = `hello string`;', errors },
@@ -278,6 +296,32 @@ ruleTester.run<string, Option[]>(name, rule, {
     { code: '<img src="./image.png" alt="some image" />', errors },
     { code: '<button aria-label="Close" type="button" />', errors },
     { code: `const test = { text: 'This is not localized' }`, errors },
+
+    {
+      code: `const notAMap: {get: (key: string) => string}; notAMap.get("string with a spaces")`,
+      options: [{ useTsTypes: true }],
+      errors,
+    },
+    { code: `var a = 'Hello guys'`, errors },
+    {
+      code: `<button className={styles.btn}>loading</button>`,
+      filename: 'a.tsx',
+      errors: [{ messageId: 'forJsxText' }],
+    },
+    {
+      code: `<button className={styles.btn}>Loading</button>`,
+      filename: 'a.tsx',
+      errors: [{ messageId: 'forJsxText' }],
+    },
+    {
+      code: "function Button({ t= 'Name'  }: {t: 'name' &  'Abs'}){} ",
+      errors,
+    },
+    {
+      code: "function Button({ t= 'Name'  }: {t: 1 |  'Abs'}){} ",
+      errors,
+    },
+    { code: "var a: {text: string} = {text: 'Bold'}", errors },
     {
       code: `function getQueryPlaceholder(compact: boolean | undefined) {
         return compact || mobileMediaQuery.matches
@@ -320,6 +364,10 @@ jsxTester.run('no-unlocalized-strings', rule, {
     {
       code: '<Trans id="missingReceipts.subtitle" description={`Call to action on missing receipt banner`} />',
     },
+    { code: "<Plural value={5} one='# Book' other='# Books' /> " },
+    { code: '<Plural value={5} one={<># Book</>} other={<># Books</>} /> ' },
+    { code: "<Select male='Ola!' other='Hello' /> " },
+    { code: "<SelectOrdinal value='Hello' one='2' other='Hello' /> " },
   ],
   invalid: [
     {
@@ -348,105 +396,6 @@ jsxTester.run('no-unlocalized-strings', rule, {
     },
     {
       code: '<Component>{someVar === 1 ? `Abc` : `Def`}</Component>',
-      errors: [{ messageId: 'default' }, { messageId: 'default' }],
-    },
-  ],
-})
-
-const tsTester = new RuleTester({
-  languageOptions: {
-    parserOptions: {
-      projectService: {
-        allowDefaultProject: ['*.ts*'],
-      },
-    },
-  },
-})
-
-tsTester.run('no-unlocalized-strings', rule, {
-  valid: [
-    { code: '<div className="hello"></div>', filename: 'a.tsx' },
-    { code: '<div className={`hello`}></div>', filename: 'a.tsx' },
-    { code: "var a: Element['nodeName']" },
-    { code: "var a: Omit<T, 'af'>" },
-    { code: `var a: 'abc' = 'abc'` },
-    { code: `var a: 'abc' | 'name'  | undefined= 'abc'` },
-    { code: "type T = {name: 'b'} ; var a: T =  {name: 'b'}" },
-    { code: "function Button({ t= 'name'  }: {t: 'name'}){} " },
-    { code: "type T ={t?:'name'|'abc'};function Button({t='name'}:T){}" },
-    {
-      code: `enum StepType {
-        Address = 'Address'
-      }`,
-    },
-    {
-      code: `enum StepType {
-        Address = \`Address\`
-      }`,
-    },
-    {
-      code: `MyComponent.myIgnoredProperty = 'MyComponent';`,
-      options: [{ ignoreProperty: ['myIgnoredProperty'] }],
-    },
-    {
-      // displayName is ignored by default
-      code: `MyComponent.displayName = 'MyComponent';`,
-    },
-    {
-      code: `const myMap = new Map(); 
-      myMap.get("string with a spaces")
-      myMap.has("string with a spaces")`,
-      options: [{ useTsTypes: true }],
-    },
-    {
-      code: `
-      const mySet = new Set(); mySet.has("string with a spaces")`,
-      options: [{ useTsTypes: true }],
-    },
-    {
-      code: `interface Foo {get: (key: string) => string}; 
-      (foo as Foo).get("string with a spaces")`,
-      options: [{ useTsTypes: true, ignoreMethodsOnTypes: ['Foo.get'] }],
-    },
-    {
-      code: `interface Foo {get: (key: string) => string};
-      const foo: Foo;
-      foo.get("string with a spaces")`,
-      options: [{ useTsTypes: true, ignoreMethodsOnTypes: ['Foo.get'] }],
-    },
-  ],
-  invalid: [
-    {
-      code: `const notAMap: {get: (key: string) => string}; notAMap.get("string with a spaces")`,
-      options: [{ useTsTypes: true }],
-      errors,
-    },
-    { code: `var a = 'Hello guys'`, errors },
-    {
-      code: `<button className={styles.btn}>loading</button>`,
-      filename: 'a.tsx',
-      errors: [{ messageId: 'forJsxText' }],
-    },
-    {
-      code: `<button className={styles.btn}>Loading</button>`,
-      filename: 'a.tsx',
-      errors: [{ messageId: 'forJsxText' }],
-    },
-    {
-      code: "function Button({ t= 'Name'  }: {t: 'name' &  'Abs'}){} ",
-      errors,
-    },
-    {
-      code: "function Button({ t= 'Name'  }: {t: 1 |  'Abs'}){} ",
-      errors,
-    },
-    { code: "var a: {text: string} = {text: 'Bold'}", errors },
-    {
-      code: `function getQueryPlaceholder(compact: boolean | undefined) {
-        return compact || mobileMediaQuery.matches
-            ? 'Search'
-            : 'Search for accounts, merchants, and more...'
-    }`,
       errors: [{ messageId: 'default' }, { messageId: 'default' }],
     },
   ],


### PR DESCRIPTION
Quote myself:

> I went through the issues with this rule and tried to address them all. It seems like we need a big change in how the rule is set up. There’s no way to make it work perfectly for everyone and every project. So, I’ve decided to remove all the built-in settings and made them fully customizable.
> 
> For example, if a user doesn’t want:
> 
> but we noticed that const CAPITAL_LETTERS is always ignored(?).
> 
> they can simply remove the related regex from their options.

This will fix 
- https://github.com/lingui/eslint-plugin/issues/28 (chinese users will be able to set their own regexp)
- const CAPITAL_LETTERS is always ignored

And possible many more issues in the future regarding the defaults. 

What was done: 

1. All hard-coded default are removed in favor of user configuration
2. Main words regex was extended to support non-Latin letters, such as Chinese or Cyrillic. 
3. `ignoreAttribute`, `ignoreProperty` and `ignoreVariable` options were merged into single `ignoreNames`
4. `strictAttribute` option removed. It didn't work properly, and now it's not needed because the user can override defaults more naturally (that was an original request for this option).
5. rule is not triggered for lingui's `msg` and `selectOrdinal` functions


## Breaking Changes

1. The rule will not have any defaults. You need to set defaults in eslint config for this rule. Refer to rule documentation for the basic configuration.
6. The `ignoreFunction` option was renamed to `ignoreFunctions`
7. `ignoreAttribute`, `ignoreProperty` and `ignoreVariable` options were merged into single `ignoreNames`
8. `strictAttribute` option removed. 