### PR TITLE
fix: support numbers in uppercase constant pattern

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -29,7 +29,7 @@ export const LinguiCallExpressionMessageQuery =
  */
 export const LinguiTransQuery = 'JSXElement[openingElement.name.name=Trans]'
 
-export const UpperCaseRegexp = /^[A-Z_-]+$/
+export const UpperCaseRegexp = /^[A-Z0-9_-]+$/
 
 export function isNativeDOMTag(str: string) {
   return DOM_TAGS.includes(str)

--- a/tests/src/rules/no-unlocalized-strings.test.ts
+++ b/tests/src/rules/no-unlocalized-strings.test.ts
@@ -216,6 +216,7 @@ ruleTester.run<string, Option[]>(name, rule, {
     { code: `const FOO = "Hello!"` },
     { code: `let FOO = "Hello!"` },
     { code: `var FOO = "Hello!"` },
+    { code: `const FOO_2 = "2"` },
 
     {
       code: `const test = "Hello!"`,


### PR DESCRIPTION
The UpperCaseRegexp was updated to handle numeric characters in constant names like FORMAT_12H or API2_CONFIG. Added corresponding test case.