### PR TITLE
feat: add no-t-call-in-react-component

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@types/jest": "^29.5.13",
     "@types/micromatch": "^4.0.9",
     "@types/node": "^20.3.3",
+    "@types/react": "^18.3.12",
     "@typescript-eslint/parser": "^8.0.0",
     "@typescript-eslint/rule-tester": "^8.0.0",
     "@typescript-eslint/scope-manager": "^8.0.0",

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -47,11 +47,14 @@ export function isAllowedDOMAttr(tag: string, attr: string, attributeNames: stri
   return false
 }
 
-export function getNearestAncestor<Type>(node: any, type: string): Type | null {
+export function getNearestAncestor<Type extends TSESTree.AST_NODE_TYPES>(
+  node: TSESTree.Node,
+  type: Type,
+): (TSESTree.Node & { type: Type }) | null {
   let temp = node.parent
   while (temp) {
     if (temp.type === type) {
-      return temp as Type
+      return temp as any
     }
     temp = temp.parent
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import * as noSingleVariablesToTranslateRule from './rules/no-single-variables-t
 import * as tCallInFunctionRule from './rules/t-call-in-function'
 import * as textRestrictionsRule from './rules/text-restrictions'
 import * as noTransInsideTransRule from './rules/no-trans-inside-trans'
+import * as noTCallInReactComponentRule from './rules/no-t-call-in-react-component'
 
 import { ESLint, Linter } from 'eslint'
 import { FlatConfig, RuleModule } from '@typescript-eslint/utils/ts-eslint'
@@ -17,6 +18,7 @@ const rules = {
   [tCallInFunctionRule.name]: tCallInFunctionRule.rule,
   [textRestrictionsRule.name]: textRestrictionsRule.rule,
   [noTransInsideTransRule.name]: noTransInsideTransRule.rule,
+  [noTCallInReactComponentRule.name]: noTCallInReactComponentRule.rule,
 }
 
 type RuleKey = keyof typeof rules
@@ -43,6 +45,7 @@ const recommendedRules: { [K in RuleKey as `lingui/${K}`]?: FlatConfig.RuleLevel
   'lingui/no-single-variables-to-translate': 'warn',
   'lingui/no-trans-inside-trans': 'warn',
   'lingui/no-expression-in-message': 'warn',
+  'lingui/no-t-call-in-react-component': 'warn',
 }
 
 // Assign configs here so we can reference `plugin`

--- a/src/rules/no-t-call-in-react-component.ts
+++ b/src/rules/no-t-call-in-react-component.ts
@@ -1,0 +1,314 @@
+import { ParserServices, TSESTree } from '@typescript-eslint/utils'
+import { createRule } from '../create-rule'
+import { RuleContext, SourceCode } from '@typescript-eslint/utils/ts-eslint'
+import ts, { type Expression, type SourceFile, type TypeChecker } from 'typescript'
+
+type Node = TSESTree.Node
+const { AST_NODE_TYPES } = TSESTree
+export const name = 'no-t-call-in-react-component'
+export const rule = createRule({
+  name,
+  meta: {
+    docs: {
+      description: 'use _(msg`...`) instead of t`...` and t() in react components',
+      recommended: 'error',
+    },
+    messages: {
+      default:
+        't`...` and t() call should not be used in react components, use _(msg`...`) instead',
+      fix1: 'Replace with _(msg`...`)',
+      fix2: 'Replace with <Trans>...</Trans>',
+    },
+    fixable: 'code',
+    hasSuggestions: true,
+    schema: [
+      {
+        type: 'object',
+        properties: {},
+        additionalProperties: false,
+      },
+    ],
+    type: 'problem' as const,
+  },
+
+  defaultOptions: [],
+
+  create: (context) => {
+    return {
+      'TaggedTemplateExpression[tag.name=t]'(node: TSESTree.TaggedTemplateExpression) {
+        const hookContainer = findAncestor(node, isHookContainer)
+        if (!hookContainer) return
+        const sourceCode = context.sourceCode
+
+        context.report({
+          node,
+          messageId: 'default',
+          suggest: [
+            {
+              messageId: 'fix1',
+              *fix(fixer) {
+                if (hookContainer.body.type !== AST_NODE_TYPES.BlockStatement) return
+                yield fixer.insertTextBefore(
+                  sourceCode.ast.body[0],
+                  "import { useLingui } from '@lingui/react';import { msg } from '@lingui/macro';",
+                )
+                yield fixer.insertTextBefore(
+                  hookContainer.body.body[0],
+                  'const { _ } = useLingui();',
+                )
+                yield fixer.replaceText(node, `_(msg${sourceCode.getText(node.quasi)})`)
+              },
+            },
+            {
+              messageId: 'fix2',
+              *fix(fixer) {
+                if (!(context.filename.endsWith('.tsx') || context.filename.endsWith('.jsx')))
+                  return
+                const parser = getParserServices(context)
+                if (!parser) return
+
+                const fixable = canFixAsJSX(parser, sourceCode, node)
+                if (!fixable) return
+                const template = node.quasi
+                if (
+                  template.type !== AST_NODE_TYPES.TemplateLiteral &&
+                  template.type !== AST_NODE_TYPES.Literal
+                )
+                  return
+
+                yield fixer.insertTextBefore(
+                  sourceCode.ast.body[0],
+                  "import { Trans } from '@lingui/macro';",
+                )
+                const text = Array.from(
+                  (function* gen() {
+                    const text = [...template.quasis]
+                    const expr = [...template.expressions]
+                    yield `<Trans>`
+                    while (true) {
+                      if (text.length) yield text.shift().value.raw
+                      if (expr.length) yield `{${sourceCode.getText(expr.shift())}}`
+                      if (!text.length && !expr.length) break
+                    }
+                    yield `</Trans>`
+                  })(),
+                ).join('')
+                const replacementNode =
+                  node.parent.type === AST_NODE_TYPES.JSXExpressionContainer &&
+                  node.parent.parent.type === AST_NODE_TYPES.JSXElement
+                    ? node.parent
+                    : node
+                yield fixer.replaceText(replacementNode, text)
+              },
+            },
+          ],
+        })
+      },
+    }
+  },
+})
+
+function findAncestor<T extends Node>(
+  node: Node,
+  callback: (node: Node) => node is T,
+): T | undefined
+function findAncestor(node: Node, callback: (node: Node) => boolean | 'quit'): Node | undefined
+function findAncestor(node: Node, callback: (node: Node) => boolean | 'quit'): Node | undefined {
+  let current: Node | undefined = node
+  while (current) {
+    const result = callback(current)
+    if (result === 'quit') return
+    if (result) return current
+    current = current.parent
+  }
+  return undefined
+}
+function isHookContainer(
+  node: Node,
+): node is
+  | TSESTree.FunctionDeclaration
+  | TSESTree.FunctionExpression
+  | TSESTree.ArrowFunctionExpression {
+  // a hook container is
+  if (
+    !(
+      node.type === AST_NODE_TYPES.FunctionDeclaration ||
+      node.type === AST_NODE_TYPES.FunctionExpression ||
+      node.type === AST_NODE_TYPES.ArrowFunctionExpression
+    )
+  )
+    return false
+
+  // a function starts with use
+  const name = getFunctionName(node)
+  if (name.startsWith('use') && name[3].toLowerCase() !== name[3]) return true
+
+  // or a function that contains a hook call
+  if (!node.body || node.body.type !== AST_NODE_TYPES.BlockStatement) return false
+  if (
+    node.body.body.some((statement) => {
+      if (statement.type === AST_NODE_TYPES.VariableDeclaration) {
+        const init = statement.declarations[0].init
+        return init && isHookCall(init)
+      } else if (statement.type === AST_NODE_TYPES.ExpressionStatement) {
+        return isHookCall(statement.expression)
+      } else return false
+    })
+  )
+    return true
+
+  // or a function that wrapped with memo(...)
+  if (node.parent.type === AST_NODE_TYPES.CallExpression) {
+    if (node.parent.callee.type === AST_NODE_TYPES.Identifier) {
+      return node.parent.callee.name === 'memo'
+    }
+    return false
+  }
+
+  // or a function that returns JSXElement
+  const last = node.body.body.at(-1)
+  return !!(
+    last &&
+    last.type === AST_NODE_TYPES.ReturnStatement &&
+    last.argument?.type === AST_NODE_TYPES.JSXElement
+  )
+}
+function getFunctionName(
+  node:
+    | TSESTree.FunctionDeclaration
+    | TSESTree.FunctionExpression
+    | TSESTree.ArrowFunctionExpression,
+): string | null {
+  if (
+    node.parent.type === AST_NODE_TYPES.VariableDeclarator &&
+    node.parent.id.type === AST_NODE_TYPES.Identifier
+  ) {
+    return node.parent.id.name
+  }
+  return node.id.name
+}
+function isHookCall(node: Node): boolean {
+  return (
+    node.type === AST_NODE_TYPES.CallExpression &&
+    node.callee.type === AST_NODE_TYPES.Identifier &&
+    node.callee.name.startsWith('use')
+  )
+}
+function canFixAsJSX(
+  parser: ParserServices,
+  sourceCode: SourceCode,
+  node: TSESTree.TaggedTemplateExpression | TSESTree.CallExpression,
+): boolean {
+  // for some simple cases like
+  // const str = cond ? t.call() : t.call2()
+  // try to detect its usage
+  const assignedVariable = findAncestor(node.parent, (node) => {
+    switch (node.type) {
+      case AST_NODE_TYPES.ConditionalExpression:
+        return false
+      case AST_NODE_TYPES.IfStatement:
+        return node.parent.type === AST_NODE_TYPES.BlockStatement
+      case AST_NODE_TYPES.BlockStatement:
+        return (
+          node.parent.type === AST_NODE_TYPES.ArrowFunctionExpression ||
+          node.parent.type === AST_NODE_TYPES.FunctionExpression ||
+          node.parent.type === AST_NODE_TYPES.IfStatement
+        )
+      // if (expr) return t.call()
+      case AST_NODE_TYPES.ReturnStatement:
+        return false
+      case AST_NODE_TYPES.FunctionExpression:
+      case AST_NODE_TYPES.ArrowFunctionExpression:
+        // const expr = useMemo(() => { ... })
+        const fnLike = node as
+          | TSESTree.FunctionDeclaration
+          | TSESTree.FunctionExpression
+          | TSESTree.ArrowFunctionExpression
+        if (fnLike.parent.type !== AST_NODE_TYPES.CallExpression) return 'quit'
+        if (
+          fnLike.parent.arguments[0] === node &&
+          fnLike.parent.callee.type === AST_NODE_TYPES.Identifier &&
+          fnLike.parent.callee.name === 'useMemo'
+        )
+          return false
+        return 'quit'
+      case AST_NODE_TYPES.VariableDeclarator:
+        return node.id.type === AST_NODE_TYPES.Identifier
+      default:
+        return 'quit'
+    }
+  })
+  const tsNode = parser.esTreeNodeToTSNodeMap.get(node)
+  const sourceFile = tsNode.getSourceFile()
+  const checker = parser.program.getTypeChecker()
+
+  if (assignedVariable) {
+    const name =
+      assignedVariable.type === AST_NODE_TYPES.VariableDeclarator &&
+      assignedVariable.id.type === AST_NODE_TYPES.Identifier
+        ? assignedVariable.id.name
+        : undefined
+    const references = sourceCode
+      .getScope(assignedVariable)
+      .variables.filter((x) => x.name === name)[0]?.references
+    const isAllUseSiteAcceptsReactNode =
+      references?.every((reference) => {
+        if (reference.identifier.parent.type === AST_NODE_TYPES.VariableDeclarator) return true
+        const tsNode = parser.esTreeNodeToTSNodeMap.get(reference.identifier)
+        if (!ts.isExpression(tsNode)) return false
+        return isReactNodeAssignableToContextualType(checker, tsNode.getSourceFile(), tsNode)
+      }) ?? true
+    if (isAllUseSiteAcceptsReactNode) {
+      return true
+    }
+  } else if (isReactNodeAssignableToContextualType(checker, sourceFile, tsNode)) {
+    return true
+  }
+  return false
+}
+
+// for code <Text>{t.xyz()}</Text> it's yes
+// for code confirm(t.xyz()) it's no
+function isReactNodeAssignableToContextualType(
+  checker: TypeChecker,
+  file: SourceFile,
+  node: Expression,
+) {
+  const apparentType = checker.getContextualType(node)
+  if (apparentType && !(apparentType.flags & ts.TypeFlags.Any)) {
+    const reactNodeType = getReactNodeType(file, checker)
+    // checker.isTypeAssignableTo is public in 5.4 beta
+    // see https://github.com/microsoft/TypeScript/pull/56448
+    // but this function is already here for a long time.
+    // TODO: remove this after upgrade to ts 5.4 or newer
+    if (reactNodeType && (checker as any).isTypeAssignableTo(reactNodeType, apparentType)) {
+      return true
+    }
+  }
+  return false
+}
+
+function getReactNodeType(position: ts.Node, checker: TypeChecker) {
+  // same, public API since 5.4 beta, see https://github.com/microsoft/TypeScript/pull/56932
+  // TODO: remove this after upgrade to ts 5.4 or newer
+  const namespace = (checker as any).resolveName('React', position, ts.SymbolFlags.Namespace, false)
+  if (!namespace) return
+  const resolvedNamespace = checker.getTypeOfSymbol(namespace).getSymbol()
+  if (!resolvedNamespace) return
+  const reactNodeSymbol = resolvedNamespace.exports?.get('ReactNode' as ts.__String)
+  if (!reactNodeSymbol) return
+  return checker.getDeclaredTypeOfSymbol(reactNodeSymbol)
+}
+
+function getParserServices(
+  context: Readonly<RuleContext<string, unknown[]>>,
+): ParserServices | undefined {
+  if (
+    context.sourceCode.parserServices?.esTreeNodeToTSNodeMap == null ||
+    context.sourceCode.parserServices.tsNodeToESTreeNodeMap == null
+  ) {
+    return undefined
+  }
+  if (context.sourceCode.parserServices.program == null) return undefined
+  return context.sourceCode.parserServices as ParserServices
+}

--- a/src/rules/no-unlocalized-strings.ts
+++ b/src/rules/no-unlocalized-strings.ts
@@ -294,10 +294,7 @@ export const rule = createRule<Option[], string>({
       'JSXAttribute :matches(Literal,TemplateLiteral)'(
         node: TSESTree.Literal | TSESTree.TemplateLiteral,
       ) {
-        const parent = getNearestAncestor<TSESTree.JSXAttribute>(
-          node,
-          TSESTree.AST_NODE_TYPES.JSXAttribute,
-        )
+        const parent = getNearestAncestor(node, TSESTree.AST_NODE_TYPES.JSXAttribute)
         const attrName = getAttrName(parent?.name?.name)
 
         // allow <MyComponent className="active" />
@@ -306,10 +303,7 @@ export const rule = createRule<Option[], string>({
           return
         }
 
-        const jsxElement = getNearestAncestor<TSESTree.JSXOpeningElement>(
-          node,
-          TSESTree.AST_NODE_TYPES.JSXOpeningElement,
-        )
+        const jsxElement = getNearestAncestor(node, TSESTree.AST_NODE_TYPES.JSXOpeningElement)
         const tagName = getIdentifierName(jsxElement?.name)
         const attributeNames = jsxElement?.attributes.map(
           (attr) => isJSXAttribute(attr) && getAttrName(attr.name.name),
@@ -412,10 +406,7 @@ export const rule = createRule<Option[], string>({
       'CallExpression :matches(Literal,TemplateLiteral)'(
         node: TSESTree.Literal | TSESTree.TemplateLiteral,
       ) {
-        const parent = getNearestAncestor<TSESTree.CallExpression>(
-          node,
-          TSESTree.AST_NODE_TYPES.CallExpression,
-        )
+        const parent = getNearestAncestor(node, TSESTree.AST_NODE_TYPES.CallExpression)
 
         if (isValidFunctionCall(parent)) {
           visited.add(node)
@@ -426,10 +417,7 @@ export const rule = createRule<Option[], string>({
       'NewExpression :matches(Literal,TemplateLiteral)'(
         node: TSESTree.Literal | TSESTree.TemplateLiteral,
       ) {
-        const parent = getNearestAncestor<TSESTree.NewExpression>(
-          node,
-          TSESTree.AST_NODE_TYPES.NewExpression,
-        )
+        const parent = getNearestAncestor(node, TSESTree.AST_NODE_TYPES.NewExpression)
 
         if (isValidFunctionCall(parent)) {
           visited.add(node)

--- a/tests/project/tsconfig.json
+++ b/tests/project/tsconfig.json
@@ -1,0 +1,5 @@
+{
+  "compilerOptions": {
+    "jsx": "react-jsx"
+  }
+}

--- a/tests/src/rules/no-t-call-in-react-component.test.ts
+++ b/tests/src/rules/no-t-call-in-react-component.test.ts
@@ -1,0 +1,186 @@
+import { rule, name } from '../../../src/rules/no-t-call-in-react-component'
+import { RuleTester, TestCaseError } from '@typescript-eslint/rule-tester'
+
+describe('', () => {})
+
+runTest(false)
+runTest(true)
+function runTest(withTypeAwareLint: boolean) {
+  const ruleTester = new RuleTester({
+    languageOptions: {
+      parserOptions: {
+        ecmaFeatures: { jsx: true },
+        projectService: withTypeAwareLint ? { allowDefaultProject: ['*.ts*'] } : undefined,
+      },
+    },
+  })
+  ruleTester.run(withTypeAwareLint ? name + '-with-type' : name, rule, {
+    valid: [
+      { code: 't`Hello`' },
+      { code: 'function hello() { return t`Hello` }' },
+      { code: 'function Hello() { return <p>{_(msg`Hello`)}</p> }' },
+      { code: 'const a = () => t`Hello`' },
+      { code: 'const a = () => t("Hello")' },
+    ],
+
+    invalid: [
+      {
+        name: 't`...` call in react hook',
+        code: `
+          function useHook() {
+            return t\`Hello\`;
+          }`,
+        errors: fix(
+          `
+          import { useLingui } from '@lingui/react';import { msg } from '@lingui/macro';function useHook() {
+            const { _ } = useLingui();return _(msg\`Hello\`);
+          }`,
+        ),
+      },
+      {
+        name: 't`...` call in JSX children',
+        code: `
+          function Component() {
+            const x = useY();
+            return <p>
+              {t\`Hello\`}
+            </p>;
+          }`,
+        errors: fix(
+          `
+          import { useLingui } from '@lingui/react';import { msg } from '@lingui/macro';function Component() {
+            const { _ } = useLingui();const x = useY();
+            return <p>
+              {_(msg\`Hello\`)}
+            </p>;
+          }`,
+          `
+          import { Trans } from '@lingui/macro';function Component() {
+            const x = useY();
+            return <p>
+              <Trans>Hello</Trans>
+            </p>;
+          }`,
+        ),
+      },
+      {
+        name: 't`...` call in JSX children with interpolation',
+        code: `
+          function Component() {
+            const x = useY();
+            return <p>
+              {t\`Hello \${name}\`}
+            </p>;
+          }`,
+        errors: fix(
+          `
+          import { useLingui } from '@lingui/react';import { msg } from '@lingui/macro';function Component() {
+            const { _ } = useLingui();const x = useY();
+            return <p>
+              {_(msg\`Hello \${name}\`)}
+            </p>;
+          }`,
+          `
+          import { Trans } from '@lingui/macro';function Component() {
+            const x = useY();
+            return <p>
+              <Trans>Hello {name}</Trans>
+            </p>;
+          }`,
+        ),
+      },
+      {
+        name: 't`...` call in ternary in JSX children',
+        code: `
+          function Component() {
+            const x = useY();
+            return <p>
+              {x ? t\`Hello\` : null}
+            </p>;
+          }`,
+        errors: fix(
+          `
+          import { useLingui } from '@lingui/react';import { msg } from '@lingui/macro';function Component() {
+            const { _ } = useLingui();const x = useY();
+            return <p>
+              {x ? _(msg\`Hello\`) : null}
+            </p>;
+          }`,
+          `
+          import { Trans } from '@lingui/macro';function Component() {
+            const x = useY();
+            return <p>
+              {x ? <Trans>Hello</Trans> : null}
+            </p>;
+          }`,
+        ),
+      },
+      {
+        name: 't`...` call used as variable',
+        code: `
+          function Component() {
+            const x = useY();
+            const message = t\`Hello\`;
+            return <p>
+              {x ? message : null}
+            </p>;
+          }`,
+        errors: fix(
+          `
+          import { useLingui } from '@lingui/react';import { msg } from '@lingui/macro';function Component() {
+            const { _ } = useLingui();const x = useY();
+            const message = _(msg\`Hello\`);
+            return <p>
+              {x ? message : null}
+            </p>;
+          }`,
+          `
+          import { Trans } from '@lingui/macro';function Component() {
+            const x = useY();
+            const message = <Trans>Hello</Trans>;
+            return <p>
+              {x ? message : null}
+            </p>;
+          }`,
+        ),
+      },
+      {
+        name: 't`...` call used as variable as string',
+        code: `
+          function Component() {
+            const x = useY();
+            const message = t\`Hello\`;
+            confirm(message);
+            return <p>
+              {x ? message : null}
+            </p>;
+          }`,
+        errors: fix(
+          `
+          import { useLingui } from '@lingui/react';import { msg } from '@lingui/macro';function Component() {
+            const { _ } = useLingui();const x = useY();
+            const message = _(msg\`Hello\`);
+            confirm(message);
+            return <p>
+              {x ? message : null}
+            </p>;
+          }`,
+        ),
+      },
+    ],
+  })
+
+  function fix(
+    code1: string,
+    code2?: string | undefined,
+  ): readonly TestCaseError<'default' | 'fix1' | 'fix2'>[] {
+    const fix1 = { messageId: 'fix1', output: code1 } as const
+    return [
+      {
+        messageId: 'default',
+        suggestions:
+          withTypeAwareLint && code2 ? [fix1, { messageId: 'fix2', output: code2 }] : [fix1],
+      },
+    ]
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1121,6 +1121,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/prop-types@npm:*":
+  version: 15.7.13
+  resolution: "@types/prop-types@npm:15.7.13"
+  checksum: 10c0/1b20fc67281902c6743379960247bc161f3f0406ffc0df8e7058745a85ea1538612109db0406290512947f9632fe9e10e7337bf0ce6338a91d6c948df16a7c61
+  languageName: node
+  linkType: hard
+
+"@types/react@npm:^18.3.12":
+  version: 18.3.12
+  resolution: "@types/react@npm:18.3.12"
+  dependencies:
+    "@types/prop-types": "npm:*"
+    csstype: "npm:^3.0.2"
+  checksum: 10c0/8bae8d9a41619804561574792e29112b413044eb0d53746dde2b9720c1f9a59f71c895bbd7987cd8ce9500b00786e53bc032dced38cddf42910458e145675290
+  languageName: node
+  linkType: hard
+
 "@types/stack-utils@npm:^2.0.0":
   version: 2.0.1
   resolution: "@types/stack-utils@npm:2.0.1"
@@ -1788,6 +1805,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"csstype@npm:^3.0.2":
+  version: 3.1.3
+  resolution: "csstype@npm:3.1.3"
+  checksum: 10c0/80c089d6f7e0c5b2bd83cf0539ab41474198579584fa10d86d0cafe0642202343cbc119e076a0b1aece191989477081415d66c9fefbf3c957fc2fc4b7009f248
+  languageName: node
+  linkType: hard
+
 "debug@npm:4, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4":
   version: 4.3.7
   resolution: "debug@npm:4.3.7"
@@ -1957,6 +1981,7 @@ __metadata:
     "@types/jest": "npm:^29.5.13"
     "@types/micromatch": "npm:^4.0.9"
     "@types/node": "npm:^20.3.3"
+    "@types/react": "npm:^18.3.12"
     "@typescript-eslint/parser": "npm:^8.0.0"
     "@typescript-eslint/rule-tester": "npm:^8.0.0"
     "@typescript-eslint/scope-manager": "npm:^8.0.0"


### PR DESCRIPTION
I added a new rule: No t call in a React Component.

## Background

There are two macros for this: `t` and `<Trans>`. The prior one is used outside of a React Component. Developers should not use `t` because it will not reflect React Provider changes (e.g. when the locale changes).

Wrong code:

```tsx
function Component() {
  const x = useY();
  return <p>
    {t`Hello`}
  </p>;
}
```

Autofix (1):

```tsx
import { useLingui } from '@lingui/react'
import { msg } from '@lingui/macro'
function Component() {
  const { _ } = useLingui();
  const x = useY();
  return <p>
    {_(msg`Hello`)}
  </p>;
}
```

Autofix (2):

This fix requires type-aware lint and only applies when the context _accepts_ a React.ReactNode.

```tsx
import { Trans } from '@lingui/macro'
function Component() {
  const x = useY();
  return <p>
    <Trans>Hello</Trans>
  </p>;
}
```