### PR TITLE
fix(no-unlocalized-strings): ignore more cases

### DIFF
--- a/docs/rules/no-unlocalized-strings.md
+++ b/docs/rules/no-unlocalized-strings.md
@@ -60,7 +60,7 @@ The rule doesn’t come with built-in ignore settings because each project is un
       ],
       // Following settings require typed linting https://typescript-eslint.io/getting-started/typed-linting/
       "useTsTypes": true,
-      "ignoreMethodsOnType": [
+      "ignoreMethodsOnTypes": [
         // Ignore specified methods on Map and Set types
         "Map.get",
         "Map.has",

--- a/docs/rules/no-unlocalized-strings.md
+++ b/docs/rules/no-unlocalized-strings.md
@@ -16,9 +16,9 @@ The rule doesn’t come with built-in ignore settings because each project is un
     "error",
     {
       "ignore": [
-        // Ignore strings that don’t start with an uppercase letter
-        //   or don't contain two words separated by whitespace
-        "^(?![A-Z].*|\\w+\\s\\w+).+$",
+        // Ignore strings which are a single "word" (no spaces) 
+        // and doesn't start with an uppercase letter
+        "^(?![A-Z])\\S+$",
         // Ignore UPPERCASE literals
         // Example: const test = "FOO"
         "^[A-Z0-9_-]+$"

--- a/src/rules/no-unlocalized-strings.ts
+++ b/src/rules/no-unlocalized-strings.ts
@@ -243,7 +243,7 @@ export const rule = createRule<Option[], string>({
       visited.add(node)
 
       const text = getText(node)
-      if (!text || isIgnoredSymbol(text)) {
+      if (!text || isIgnoredSymbol(text) || isTextWhiteListed(text)) {
         return
       }
 
@@ -481,9 +481,9 @@ export const rule = createRule<Option[], string>({
       },
       'TemplateLiteral:exit'(node: TSESTree.TemplateLiteral) {
         if (visited.has(node)) return
-        const quasisValue = getText(node)
+        const text = getText(node)
 
-        if (isTextWhiteListed(quasisValue)) return
+        if (!text || isTextWhiteListed(text)) return
 
         context.report({ node, messageId: 'default' })
       },

--- a/tests/src/rules/no-unlocalized-strings.test.ts
+++ b/tests/src/rules/no-unlocalized-strings.test.ts
@@ -40,8 +40,12 @@ ruleTester.run<string, Option[]>(name, rule, {
       code: 'const t = `${BRAND_NAME}`',
     },
     {
-      name: 'should ignore strings containing only variables 2',
+      name: 'should ignore strings containing few variables',
       code: 'const t = `${BRAND_NAME}${BRAND_NAME}`',
+    },
+    {
+      name: 'should ignore strings containing few variables with spaces',
+      code: 'const t = ` ${BRAND_NAME} ${BRAND_NAME} `',
     },
     {
       code: 'hello("Hello")',
@@ -142,6 +146,10 @@ ruleTester.run<string, Option[]>(name, rule, {
     { code: '<img src={`./image.png`} />' },
     { code: '<button type="button" for="form-id" />' },
     { code: '<button type={`button`} for={`form-id`} />' },
+    {
+      name: 'JSX Space should not be flagged',
+      code: `<button/>{' '}<button/>`,
+    },
     { code: '<DIV foo="bar" />', options: [{ ignoreNames: ['foo'] }] },
     { code: '<DIV foo={`Bar`} />', options: [{ ignoreNames: ['foo'] }] },
     {
@@ -379,6 +387,12 @@ jsxTester.run('no-unlocalized-strings', rule, {
   valid: [
     { code: '<Component>{ i18n._("abc") }</Component>' },
     { code: '<Component>{ i18n._(`abc`) }</Component>' },
+    {
+      name: 'Should not flag the JSX text with only spaces and interpolations',
+      code: `<Component>
+        {variable}
+        </Component>`,
+    },
     { code: '<Trans>Hello</Trans>' },
     { code: '<Trans><Component>Hello</Component></Trans>' },
     {

--- a/tests/src/rules/no-unlocalized-strings.test.ts
+++ b/tests/src/rules/no-unlocalized-strings.test.ts
@@ -36,6 +36,14 @@ ruleTester.run<string, Option[]>(name, rule, {
       code: 'const a = `0123456789!@#$%^&*()_+|~-=\\`[]{};\':",./<>?`;',
     },
     {
+      name: 'should ignore strings containing only variables',
+      code: 'const t = `${BRAND_NAME}`',
+    },
+    {
+      name: 'should ignore strings containing only variables 2',
+      code: 'const t = `${BRAND_NAME}${BRAND_NAME}`',
+    },
+    {
       code: 'hello("Hello")',
       options: [{ ignoreFunctions: ['hello'] }],
     },
@@ -92,6 +100,15 @@ ruleTester.run<string, Option[]>(name, rule, {
     //     // JSX
     { code: '<div className="primary"></div>' },
     { code: '<div className={`primary`}></div>' },
+    {
+      name: 'Should ignore non-word strings in the JSX Text',
+      code: `<span>+</span>`,
+    },
+    {
+      name: 'Should JSX Text if it matches the ignore option',
+      code: `<span>foo</span>`,
+      options: [{ ignore: ['^foo'] }],
+    },
     { code: '<div className={a ? "active": "inactive"}></div>' },
     { code: '<div className={a ? `active`: `inactive`}></div>' },
     { code: '<div>{i18n._("foo")}</div>' },
@@ -414,4 +431,28 @@ jsxTester.run('no-unlocalized-strings', rule, {
       errors: [{ messageId: 'default' }, { messageId: 'default' }],
     },
   ],
+})
+
+/**
+ * This test is covering the ignore regex proposed in the documentation
+ * This regex doesn't used directly in the code.
+ */
+describe('Default ignore regex', () => {
+  const regex = '^(?![A-Z])\\S+$'
+
+  test.each([
+    ['hello', true],
+    ['helloMyVar', true],
+    ['package.json', true],
+    ['./src/**/*.test*', true],
+    ['camel_case', true],
+
+    // Start from capital letter
+    ['Hello', false],
+    // Multiword string (has space)
+    ['hello world', false],
+    ['Hello World', false],
+  ])('validate %s', (str, pass) => {
+    expect(new RegExp(regex).test(str)).toBe(pass)
+  })
 })

--- a/tests/src/rules/no-unlocalized-strings.test.ts
+++ b/tests/src/rules/no-unlocalized-strings.test.ts
@@ -148,7 +148,7 @@ ruleTester.run<string, Option[]>(name, rule, {
     { code: '<button type={`button`} for={`form-id`} />' },
     {
       name: 'JSX Space should not be flagged',
-      code: `<button/>{' '}<button/>`,
+      code: `<button>{' '}</button>`,
     },
     { code: '<DIV foo="bar" />', options: [{ ignoreNames: ['foo'] }] },
     { code: '<DIV foo={`Bar`} />', options: [{ ignoreNames: ['foo'] }] },


### PR DESCRIPTION
- ignore when there is no text, and only variables
- apply `ignore` option to the JSX Text
- improve default Regexp in the documentation