### PR TITLE
fix: no-unlocalized-strings rule to ignore default parameter values specified in ignoreNames

### DIFF
--- a/src/rules/no-unlocalized-strings.ts
+++ b/src/rules/no-unlocalized-strings.ts
@@ -487,6 +487,16 @@ export const rule = createRule<Option[], string>({
 
         context.report({ node, messageId: 'default' })
       },
+
+      'AssignmentPattern > :matches(Literal,TemplateLiteral)'(
+        node: TSESTree.Literal | TSESTree.TemplateLiteral,
+      ) {
+        const parent = node.parent as TSESTree.AssignmentPattern
+
+        if (isIdentifier(parent.left) && isIgnoredName(parent.left.name)) {
+          visited.add(node)
+        }
+      },
     }
 
     function wrapVisitor<

--- a/tests/src/rules/no-unlocalized-strings.test.ts
+++ b/tests/src/rules/no-unlocalized-strings.test.ts
@@ -199,6 +199,7 @@ ruleTester.run<string, Option[]>(name, rule, {
       options: [{ ignoreNames: ['displayName'] }],
     },
     {
+      name: 'Respect the name of the parameter when a default is applied',
       code: 'function Input({ intent = "none"}) {}',
       options: [{ ignoreNames: ['intent'] }],
     },

--- a/tests/src/rules/no-unlocalized-strings.test.ts
+++ b/tests/src/rules/no-unlocalized-strings.test.ts
@@ -199,6 +199,10 @@ ruleTester.run<string, Option[]>(name, rule, {
       options: [{ ignoreNames: ['displayName'] }],
     },
     {
+      code: 'function Input({ intent = "none"}) {}',
+      options: [{ ignoreNames: ['intent'] }],
+    },
+    {
       name: 'computed keys should be ignored by default, StringLiteral',
       code: `obj["key with space"] = 5`,
     },


### PR DESCRIPTION
**Description:**

This PR addresses an issue where the `no-unlocalized-strings` ESLint rule incorrectly flags default parameter values as unlocalized strings, even when their parameter names are included in the `ignoreNames` option.

**Background:**

Given the following code and ESLint configuration:

```javascript
// Code
function Input({ intent = "none" }) {}

// ESLint Configuration
{
  "rules": {
    "no-unlocalized-strings": ["error", { "ignoreNames": ["intent"] }]
  }
}
```

The string `"none"` assigned as a default value to `intent` should be ignored, but it is currently being reported as an error.

**Solution:**

Added a handler for `AssignmentPattern` nodes to check if the parameter name is in `ignoreNames`. If it is, the default value is ignored by adding it to the `visited` set.

**Testing:**

- Confirmed that default parameter values are now correctly ignored when the parameter name is specified in `ignoreNames`.
- Ensured that other functionalities of the rule remain unaffected.
- Passed all existing tests and added a new test case for this scenario.

**Notes:**

This is my first PR to this project. I'm open to any feedback or suggestions for improvement. Thank you for considering my contribution!