### PR TITLE
fix: no-unlocalized-strings rule to correctly handle as const assertions in property values with ignoreNames

### DIFF
--- a/tests/src/rules/no-unlocalized-strings.test.ts
+++ b/tests/src/rules/no-unlocalized-strings.test.ts
@@ -204,6 +204,7 @@ ruleTester.run<string, Option[]>(name, rule, {
       options: [{ ignoreNames: ['intent'] }],
     },
     {
+      name: "Should support ignoreNames when applied the 'as const' assertion",
       code: 'const Shape = { CIRCLE: "circle" as const };',
       options: [{ ignoreNames: [{ regex: { pattern: '^[A-Z0-9_-]+$' } }] }],
     },

--- a/tests/src/rules/no-unlocalized-strings.test.ts
+++ b/tests/src/rules/no-unlocalized-strings.test.ts
@@ -204,6 +204,10 @@ ruleTester.run<string, Option[]>(name, rule, {
       options: [{ ignoreNames: ['intent'] }],
     },
     {
+      code: 'const Shape = { CIRCLE: "circle" as const };',
+      options: [{ ignoreNames: [{ regex: { pattern: '^[A-Z0-9_-]+$' } }] }],
+    },
+    {
       name: 'computed keys should be ignored by default, StringLiteral',
       code: `obj["key with space"] = 5`,
     },
@@ -267,13 +271,13 @@ ruleTester.run<string, Option[]>(name, rule, {
     },
 
     {
-      code: `const myMap = new Map(); 
+      code: `const myMap = new Map();
       myMap.get("string with a spaces")
       myMap.has("string with a spaces")`,
       options: [{ useTsTypes: true, ignoreMethodsOnTypes: ['Map.get', 'Map.has'] }],
     },
     {
-      code: `interface Foo {get: (key: string) => string}; 
+      code: `interface Foo {get: (key: string) => string};
       (foo as Foo).get("string with a spaces")`,
       options: [{ useTsTypes: true, ignoreMethodsOnTypes: ['Foo.get'] }],
     },


### PR DESCRIPTION
**Description:**

This PR fixes an issue in the `no-unlocalized-strings` ESLint rule where string literals assigned to object properties are incorrectly reported as unlocalized strings when using TypeScript's `as const` assertions, even if the property names are specified in the `ignoreNames` option.

**Background:**

When using the `ignoreNames` option with a regex pattern to ignore certain property names, the rule should not report string literals assigned to those properties. However, if the property value includes an `as const` assertion, the rule fails to recognize it due to the `TSAsExpression` node introduced by the TypeScript assertion.

**Example:**

Given the ESLint configuration:

```json
{
  "rules": {
    "no-unlocalized-strings": [
      "error",
      { "ignoreNames": [{ "regex": { "pattern": "^[A-Z0-9_-]+$" } }] }
    ]
  }
}
```

The following code incorrectly reports errors for the string literals `"circle"` and `"rectangle"`:

```typescript
export const Shape = {
  CIRCLE: "circle" as const,
  RECTANGLE: "rectangle" as const,
};
```

**Cause of the Issue:**

The `as const` assertion wraps the string literal in a `TSAsExpression` node in the Abstract Syntax Tree (AST). The existing rule does not handle `TSAsExpression` nodes when processing property values, so it fails to apply the `ignoreNames` logic to the unwrapped string literals.

**Solution:**

The fix involves updating the rule to handle `TSAsExpression` nodes by unwrapping them to access the underlying string literals. Specifically:

1. **Implemented an Unwrapping Helper Function:**

   Added a helper function `unwrapTSAsExpression` to recursively unwrap `TSAsExpression` nodes:

   ```typescript
   function unwrapTSAsExpression(
     node: TSESTree.Expression,
   ): TSESTree.Literal | TSESTree.TemplateLiteral | TSESTree.Expression {
     while (node.type === TSESTree.AST_NODE_TYPES.TSAsExpression) {
       node = node.expression;
     }
     return node;
   }
   ```

2. **Updated the `isStringLiteral` Function:**

   Modified `isStringLiteral` to handle `TSAsExpression` nodes:

   ```typescript
   function isStringLiteral(node: TSESTree.Node | null | undefined): boolean {
     if (!node) return false;

     if (node.type === TSESTree.AST_NODE_TYPES.TSAsExpression) {
       return isStringLiteral(node.expression);
     }

     switch (node.type) {
       case TSESTree.AST_NODE_TYPES.Literal:
         return typeof node.value === 'string';
       case TSESTree.AST_NODE_TYPES.TemplateLiteral:
         return true;
       case TSESTree.AST_NODE_TYPES.JSXText:
         return true;
       default:
         return false;
     }
   }
   ```

3. **Modified the Visitor to Handle `TSAsExpression` Nodes:**

   Updated the visitor function for `Property` nodes to unwrap `TSAsExpression` nodes when processing property values:

   ```typescript
   'Property > :matches(Literal, TemplateLiteral, TSAsExpression)'(
     node: TSESTree.Literal | TSESTree.TemplateLiteral | TSESTree.TSAsExpression,
   ) {
     const parent = node.parent as TSESTree.Property;

     if (
       (isIdentifier(parent.key) && isIgnoredName(parent.key.name)) ||
       ((isLiteral(parent.key) || isTemplateLiteral(parent.key)) &&
         isIgnoredName(getText(parent.key)))
     ) {
       const unwrappedNode = unwrapTSAsExpression(node);

       if (isLiteral(unwrappedNode) || isTemplateLiteral(unwrappedNode)) {
         visited.add(unwrappedNode);
       }
     }
   },
   ```

**Testing:**

- **Manual Testing:**
  - Verified that with the `ignoreNames` option configured, the linter no longer reports errors for string literals assigned to property names matching the regex pattern, even when using `as const` assertions.
- **Automated Testing:**
  - Ran the existing test suite to ensure no regressions were introduced.
  - Added new test cases to cover scenarios involving `as const` assertions in property values.

**Notes:**

- **Minimal Changes:** The fix is minimal and specifically targets the handling of `TSAsExpression` nodes in property values, avoiding changes that could affect other parts of the rule.
- **TypeScript Compatibility:** The solution ensures compatibility with TypeScript features, making the rule more robust when analyzing TypeScript code.
- **No Regressions:** Care was taken to ensure that existing functionality remains unaffected, and that the fix does not introduce any new issues.

**Conclusion:**

This PR improves the `no-unlocalized-strings` rule by correctly handling `as const` assertions in property values when using the `ignoreNames` option. It ensures that string literals assigned to ignored property names are not incorrectly reported as unlocalized strings.