### PR TITLE
fix: `no-unlocalized-strings` rule to ignore string literals in expressions assigned to variables specified in `ignoreNames`

### DIFF
--- a/src/rules/no-unlocalized-strings.ts
+++ b/src/rules/no-unlocalized-strings.ts
@@ -253,6 +253,7 @@ export const rule = createRule<Option[], string>({
             isValidFunctionCall(callee)
           )
         }
+        /* istanbul ignore next */
         default:
           return false
       }
@@ -288,6 +289,7 @@ export const rule = createRule<Option[], string>({
         case TSESTree.AST_NODE_TYPES.JSXText:
           return true
         default:
+          /* istanbul ignore next */
           return false
       }
     }
@@ -313,6 +315,7 @@ export const rule = createRule<Option[], string>({
         parent = parent.parent
       }
 
+      /* istanbul ignore next */
       return false
     }
 
@@ -341,6 +344,7 @@ export const rule = createRule<Option[], string>({
         return
       }
 
+      /* istanbul ignore next */
       // If neither JSXText nor a Literal inside JSX, fall back to default messageId.
       context.report({ node, messageId: 'default' })
     }

--- a/src/rules/no-unlocalized-strings.ts
+++ b/src/rules/no-unlocalized-strings.ts
@@ -253,8 +253,8 @@ export const rule = createRule<Option[], string>({
             isValidFunctionCall(callee)
           )
         }
+        /* istanbul ignore next */
         default:
-          /* istanbul ignore next */
           return false
       }
     }

--- a/src/rules/no-unlocalized-strings.ts
+++ b/src/rules/no-unlocalized-strings.ts
@@ -253,7 +253,6 @@ export const rule = createRule<Option[], string>({
             isValidFunctionCall(callee)
           )
         }
-        /* istanbul ignore next */
         default:
           return false
       }
@@ -289,7 +288,6 @@ export const rule = createRule<Option[], string>({
         case TSESTree.AST_NODE_TYPES.JSXText:
           return true
         default:
-          /* istanbul ignore next */
           return false
       }
     }
@@ -315,7 +313,6 @@ export const rule = createRule<Option[], string>({
         parent = parent.parent
       }
 
-      /* istanbul ignore next */
       return false
     }
 
@@ -344,7 +341,6 @@ export const rule = createRule<Option[], string>({
         return
       }
 
-      /* istanbul ignore next */
       // If neither JSXText nor a Literal inside JSX, fall back to default messageId.
       context.report({ node, messageId: 'default' })
     }

--- a/src/rules/no-unlocalized-strings.ts
+++ b/src/rules/no-unlocalized-strings.ts
@@ -254,6 +254,7 @@ export const rule = createRule<Option[], string>({
           )
         }
         default:
+          /* istanbul ignore next */
           return false
       }
     }
@@ -288,6 +289,7 @@ export const rule = createRule<Option[], string>({
         case TSESTree.AST_NODE_TYPES.JSXText:
           return true
         default:
+          /* istanbul ignore next */
           return false
       }
     }

--- a/src/rules/no-unlocalized-strings.ts
+++ b/src/rules/no-unlocalized-strings.ts
@@ -73,15 +73,6 @@ function createMatcher(patterns: MatcherDef[]) {
   }
 }
 
-function unwrapTSAsExpression(
-  node: TSESTree.Expression,
-): TSESTree.Literal | TSESTree.TemplateLiteral | TSESTree.Expression {
-  while (node.type === TSESTree.AST_NODE_TYPES.TSAsExpression) {
-    node = node.expression
-  }
-  return node
-}
-
 function isAcceptableExpression(node: TSESTree.Node): boolean {
   switch (node.type) {
     case TSESTree.AST_NODE_TYPES.Literal:

--- a/tests/src/rules/no-unlocalized-strings.test.ts
+++ b/tests/src/rules/no-unlocalized-strings.test.ts
@@ -217,6 +217,21 @@ ruleTester.run<string, Option[]>(name, rule, {
       code: `obj[\`key with space\`] = 5`,
     },
     {
+      name: 'Supports default value assignment',
+      code: 'const variant = input || "body"',
+      options: [{ ignoreNames: ['variant'] }],
+    },
+    {
+      name: 'Supports nullish coalescing operator',
+      code: 'const variant = input ?? "body"',
+      options: [{ ignoreNames: ['variant'] }],
+    },
+    {
+      name: 'Supports ternary operator',
+      code: 'const value = condition ? "yes" : "no"',
+      options: [{ ignoreNames: ['value'] }],
+    },
+    {
       code: `const test = "Hello!"`,
       options: [{ ignoreNames: ['test'] }],
     },

--- a/tests/src/rules/no-unlocalized-strings.test.ts
+++ b/tests/src/rules/no-unlocalized-strings.test.ts
@@ -232,6 +232,11 @@ ruleTester.run<string, Option[]>(name, rule, {
       options: [{ ignoreNames: ['value'] }],
     },
     {
+      name: 'Ignores literals in assignment expression after variable declaration',
+      code: `let variant; variant = input ?? "body";`,
+      options: [{ ignoreNames: ['variant'] }],
+    },
+    {
       code: `const test = "Hello!"`,
       options: [{ ignoreNames: ['test'] }],
     },
@@ -311,6 +316,12 @@ ruleTester.run<string, Option[]>(name, rule, {
     { code: 'export const a = `hello string`;', errors },
     { code: "const ge = 'Select tax code'", errors },
     { code: 'const a = `Foo`;', errors },
+    {
+      name: 'Reports error when variable name is not in ignoreNames',
+      code: 'const other = input ?? "body";',
+      options: [{ ignoreNames: ['variant'] }],
+      errors: [{ messageId: 'default', line: 1, column: 24 }],
+    },
     { code: 'const a = call(`Ffo`);', errors },
     { code: 'var a = {foo: `Bar`};', errors },
     {

--- a/tests/src/rules/no-unlocalized-strings.test.ts
+++ b/tests/src/rules/no-unlocalized-strings.test.ts
@@ -353,6 +353,12 @@ ruleTester.run<string, Option[]>(name, rule, {
       options: [{ ignoreNames: ['variant'] }],
       errors: [{ messageId: 'default', line: 1, column: 36 }],
     },
+    {
+      name: 'Reports error for assignment expression to object property not in ignoreNames',
+      code: 'const variant = myFunction({someProperty: "Hello World!"})',
+      options: [{ ignoreNames: ['variant'] }],
+      errors: [{ messageId: 'default', line: 1, column: 43 }],
+    },
     { code: 'const a = call(`Ffo`);', errors },
     { code: 'var a = {foo: `Bar`};', errors },
     {

--- a/tests/src/rules/no-unlocalized-strings.test.ts
+++ b/tests/src/rules/no-unlocalized-strings.test.ts
@@ -242,6 +242,11 @@ ruleTester.run<string, Option[]>(name, rule, {
       options: [{ ignoreNames: ['variant'] }],
     },
     {
+      name: 'Ignores literals assigned to object properties when property name is in ignoreNames',
+      code: `const obj = {}; obj.variant = "body";`,
+      options: [{ ignoreNames: ['variant'] }],
+    },
+    {
       code: `const test = "Hello!"`,
       options: [{ ignoreNames: ['test'] }],
     },
@@ -326,6 +331,12 @@ ruleTester.run<string, Option[]>(name, rule, {
       code: 'const other = input ?? "body";',
       options: [{ ignoreNames: ['variant'] }],
       errors: [{ messageId: 'default', line: 1, column: 24 }],
+    },
+    {
+      name: 'Reports error for assignment expression to variable not in ignoreNames',
+      code: `let otherVariable; otherVariable = "body";`,
+      options: [{ ignoreNames: ['variant'] }],
+      errors: [{ messageId: 'default', line: 1, column: 36 }],
     },
     { code: 'const a = call(`Ffo`);', errors },
     { code: 'var a = {foo: `Bar`};', errors },

--- a/tests/src/rules/no-unlocalized-strings.test.ts
+++ b/tests/src/rules/no-unlocalized-strings.test.ts
@@ -383,6 +383,10 @@ ruleTester.run<string, Option[]>(name, rule, {
       errors: [{ messageId: 'default', line: 1, column: 24 }],
     },
     {
+      code: 'const comp = <div>{myFunction("Hello world")}</div>',
+      errors: [{ messageId: 'default' }],
+    },
+    {
       name: 'Reports error for assignment expression to variable not in ignoreNames',
       code: `let otherVariable; otherVariable = "body";`,
       options: [{ ignoreNames: ['variant'] }],

--- a/tests/src/rules/no-unlocalized-strings.test.ts
+++ b/tests/src/rules/no-unlocalized-strings.test.ts
@@ -342,6 +342,11 @@ ruleTester.run<string, Option[]>(name, rule, {
     { code: "const ge = 'Select tax code'", errors },
     { code: 'const a = `Foo`;', errors },
     {
+      name: 'Reports error for unlocalized strings inside JSX',
+      code: '<div>{"Hello World!"}</div>',
+      errors: [{ messageId: 'forJsxText', line: 1, column: 7 }],
+    },
+    {
       name: 'Reports error when variable name is not in ignoreNames',
       code: 'const other = input ?? "body";',
       options: [{ ignoreNames: ['variant'] }],
@@ -495,11 +500,11 @@ jsxTester.run('no-unlocalized-strings', rule, {
     },
     {
       code: '<Component>{"Hello"}</Component>',
-      errors,
+      errors: [{ messageId: 'forJsxText' }],
     },
     {
       code: '<Component>{`Hello`}</Component>',
-      errors,
+      errors: [{ messageId: 'forJsxText' }],
     },
     {
       code: '<Component>abc</Component>',
@@ -507,11 +512,11 @@ jsxTester.run('no-unlocalized-strings', rule, {
     },
     {
       code: "<Component>{'abc'}</Component>",
-      errors,
+      errors: [{ messageId: 'forJsxText' }],
     },
     {
       code: '<Component>{`abc`}</Component>',
-      errors,
+      errors: [{ messageId: 'forJsxText' }],
     },
     {
       code: '<Component>{someVar === 1 ? `Abc` : `Def`}</Component>',

--- a/tests/src/rules/no-unlocalized-strings.test.ts
+++ b/tests/src/rules/no-unlocalized-strings.test.ts
@@ -209,6 +209,26 @@ ruleTester.run<string, Option[]>(name, rule, {
       options: [{ ignoreNames: [{ regex: { pattern: '^[A-Z0-9_-]+$' } }] }],
     },
     {
+      name: 'Does not report when literal is assigned to an object property named in ignoreNames',
+      code: 'const x = { variant: "Hello!" }',
+      options: [{ ignoreNames: ['variant'] }],
+    },
+    {
+      name: 'Does not report when template literal is assigned to an object property named in ignoreNames',
+      code: 'const x = { variant: `Hello ${"World"}` }',
+      options: [{ ignoreNames: ['variant'] }],
+    },
+    {
+      name: 'Does not report with nullish coalescing inside object property named in ignoreNames',
+      code: 'const x = { variant: props.variant ?? "body" }',
+      options: [{ ignoreNames: ['variant'] }],
+    },
+    {
+      name: 'Does not report with ternary operator inside object property named in ignoreNames',
+      code: 'const x = { variant: condition ? "yes" : "no" }',
+      options: [{ ignoreNames: ['variant'] }],
+    },
+    {
       name: 'computed keys should be ignored by default, StringLiteral',
       code: `obj["key with space"] = 5`,
     },

--- a/tests/src/rules/no-unlocalized-strings.test.ts
+++ b/tests/src/rules/no-unlocalized-strings.test.ts
@@ -237,6 +237,11 @@ ruleTester.run<string, Option[]>(name, rule, {
       options: [{ ignoreNames: ['variant'] }],
     },
     {
+      name: 'Ignores literals in assignment expression to variable in ignoreNames',
+      code: `let variant; variant = "body";`,
+      options: [{ ignoreNames: ['variant'] }],
+    },
+    {
       code: `const test = "Hello!"`,
       options: [{ ignoreNames: ['test'] }],
     },

--- a/tests/src/rules/no-unlocalized-strings.test.ts
+++ b/tests/src/rules/no-unlocalized-strings.test.ts
@@ -232,6 +232,21 @@ ruleTester.run<string, Option[]>(name, rule, {
       options: [{ ignoreNames: ['value'] }],
     },
     {
+      name: 'Supports default value assignment - template literal version',
+      code: 'const variant = input || `body`',
+      options: [{ ignoreNames: ['variant'] }],
+    },
+    {
+      name: 'Supports nullish coalescing operator - template literal version',
+      code: 'const variant = input ?? `body`',
+      options: [{ ignoreNames: ['variant'] }],
+    },
+    {
+      name: 'Supports ternary operator - template literal version',
+      code: 'const value = condition ? `yes` : `no`',
+      options: [{ ignoreNames: ['value'] }],
+    },
+    {
       name: 'Ignores literals in assignment expression after variable declaration',
       code: `let variant; variant = input ?? "body";`,
       options: [{ ignoreNames: ['variant'] }],

--- a/tests/src/rules/no-unlocalized-strings.test.ts
+++ b/tests/src/rules/no-unlocalized-strings.test.ts
@@ -262,6 +262,16 @@ ruleTester.run<string, Option[]>(name, rule, {
       options: [{ ignoreNames: ['variant'] }],
     },
     {
+      name: 'Covers Literal in a nullish coalescing acceptable expression',
+      code: 'const variant = input ?? "Hello!";',
+      options: [{ ignoreNames: ['variant'] }],
+    },
+    {
+      name: 'Covers TemplateLiteral in a ternary acceptable expression',
+      code: 'const variant = condition ? `Hello ${"World"}` : `Fallback`;',
+      options: [{ ignoreNames: ['variant'] }],
+    },
+    {
       code: `const test = "Hello!"`,
       options: [{ ignoreNames: ['test'] }],
     },


### PR DESCRIPTION
**Description:**

This PR addresses an issue in the `no-unlocalized-strings` ESLint rule where string literals within expressions assigned to variables are incorrectly reported as unlocalized strings, even when the variable names are specified in the `ignoreNames` option.

**Background:**

When using the `ignoreNames` option to ignore certain variable names, the rule should not report string literals assigned to those variables. However, if the string literal is part of an expression (e.g., using the nullish coalescing operator `??`, logical OR `||`, or ternary `? :`), the rule currently fails to recognize it and reports an error.

**Example:**

Given the ESLint configuration:

```json
{
  "rules": {
    "no-unlocalized-strings": [
      "error",
      { "ignoreNames": ["variant"] }
    ]
  }
}
```

The following code incorrectly reports an error for the string literals `"body"`, `"yes"`, and `"no"`:

```javascript
const variant = input ?? "body";
const variant = input || "body";
const variant = condition ? "yes" : "no";
```

**Cause of the Issue:**

The rule does not currently check whether a string literal is part of an expression assigned to a variable specified in `ignoreNames`. It only handles direct assignments of string literals.

**Solution:**

To fix this issue, I modified the `'Literal:exit'` and `'TemplateLiteral:exit'` handlers in the rule to traverse up the Abstract Syntax Tree (AST) and check if the literal is part of a `VariableDeclarator` or `AssignmentExpression` where the variable name matches an entry in `ignoreNames`. If it is, the rule will ignore the literal and not report an error.

**Explanation:**

- **Traverse Up the AST:** The handlers now traverse up the AST from the literal node to check if it's part of a variable declaration or assignment where the variable name matches an entry in `ignoreNames`.
- **Check Variable Names:** If a matching variable name is found, the handler returns early, and the literal is not reported.
- **Minimal Changes:** This fix is minimal and does not introduce new visitor functions or complex recursion, reducing the risk of regressions.

**Testing:**

- **Manual Testing:**
  - Verified that string literals in expressions assigned to variables specified in `ignoreNames` are no longer reported.
  - Tested with various expressions, including nullish coalescing (`??`), logical OR (`||`), and ternary (`? :`) operators.

- **Automated Testing:**
  - Ran the existing test suite to ensure no regressions were introduced.
  - Added new test cases to cover scenarios involving string literals within expressions assigned to variables in `ignoreNames`.

**Conclusion:**

This PR improves the `no-unlocalized-strings` rule by ensuring that string literals within expressions assigned to variables specified in `ignoreNames` are correctly ignored, aligning the rule's behavior with user expectations and the documentation.