### PR TITLE
fix: optional ts and union type enhancements

### DIFF
--- a/src/rules/no-unlocalized-strings.ts
+++ b/src/rules/no-unlocalized-strings.ts
@@ -153,7 +153,10 @@ function isStringLiteralFromUnionType(
       if (type.flags & TypeFlags.Union) {
         const unionType = type as UnionType
         return unionType.types.every(
-          (t) => t.flags & TypeFlags.StringLiteral || t.flags & TypeFlags.NumberLike,
+          (t) =>
+            t.flags & TypeFlags.StringLiteral ||
+            t.flags & TypeFlags.NumberLike ||
+            t.flags & TypeFlags.BooleanLike,
         )
       }
       return !!(type.flags & TypeFlags.StringLiteral)

--- a/tests/src/rules/no-unlocalized-strings.test.ts
+++ b/tests/src/rules/no-unlocalized-strings.test.ts
@@ -188,6 +188,14 @@ ruleTester.run(name, rule, {
       options: [{ useTsTypes: true }],
     },
     {
+      name: 'allows string literal in function parameter with union type with booleans',
+      code: `
+        function test(param: "a" | "b" | false) {}
+        test("a");
+      `,
+      options: [{ useTsTypes: true }],
+    },
+    {
       name: 'allows string literal in method parameter with union type',
       code: `
         class Test {


### PR DESCRIPTION
- Make import of `TypeFlags` from `typescript` optional by using legacy `require` which is still available because of CommonJS compilation target.
- Improved support for common union types in TS with enhancements to combinations with `undefined`, `null` and numbers.