### PR TITLE
fix: match only Literal, TemplateLiteral

### DIFF
--- a/src/rules/no-unlocalized-strings.ts
+++ b/src/rules/no-unlocalized-strings.ts
@@ -474,7 +474,7 @@ export const rule = createRule<Option[], string>({
         processTextNode(node)
       },
 
-      'JSXAttribute :matches(Literal,TemplateLiteral)'(
+      'JSXAttribute > :matches(Literal,TemplateLiteral)'(
         node: TSESTree.Literal | TSESTree.TemplateLiteral,
       ) {
         const parent = getNearestAncestor<TSESTree.JSXAttribute>(


### PR DESCRIPTION
## Summary

This PR fixes a bug where hardcoded strings within JSX attributes were not consistently detected by the plugin. In particular, string literals inside event handlers (e.g., `onClick={() => alert("unlocalized string")}`) were being skipped unintentionally.

## What’s Fixed

I updated the selector:

```ts
'JSXAttribute > :matches(Literal, TemplateLiteral)'
```

This ensures that only direct children of `JSXAttribute` are matched — such as `aria-hidden="true"` — and not literals nested inside expressions.

## Before

```tsx
<button onClick={() => alert('not linted')}>
  ...
</button>
```

The string `"not linted"` was **not** reported. This is because the `JSXAttribute` node (`onClick`) was associated with a native DOM element (`<button>`) and skipped via `helper.ts`, after being added to the visited map. Thus, its subtree was not evaluated.

## After

```tsx
<button onClick={() => alert('linted')}>
  ...
</button>
```

The string `"linted"` **is** now reported correctly. Since the literal is **not** a direct child of a `JSXAttribute`, it is instead evaluated during the `Literal:exit` or `TemplateLiteral:exit` phase — ensuring the plugin inspects it properly.

## Why It Matters

This change separates static attribute values from expressions and ensures hardcoded strings inside expressions are evaluated in the correct traversal phase, fixing false negatives without introducing false positives.