### PR TITLE
feat(recommended): remove `no-expression-in-message`

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,11 +98,12 @@ Alternatively, add `lingui` to the plugins section, and configure the rules you 
 
 ✅ - Recommended
 
-- ✅ [no-expression-in-message](docs/rules/no-expression-in-message.md)
 - ✅ [no-single-tag-to-translate](docs/rules/no-single-tag-to-translate.md)
 - ✅ [no-single-variables-to-translate](docs/rules/no-single-variables-to-translate.md)
 - ✅ [no-trans-inside-trans](docs/rules/no-trans-inside-trans.md)
 - ✅ [t-call-in-function](docs/rules/t-call-in-function.md)
+
+- [consistent-plural-format](docs/rules/consistent-plural-format.md)
+- [no-expression-in-message](docs/rules/no-expression-in-message.md)
 - [no-unlocalized-strings](docs/rules/no-unlocalized-strings.md)
 - [text-restrictions](docs/rules/text-restrictions.md)
-- [consistent-plural-format](docs/rules/consistent-plural-format.md)

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,7 +44,6 @@ const recommendedRules: { [K in RuleKey as `lingui/${K}`]?: FlatConfig.RuleLevel
   'lingui/no-single-tag-to-translate': 'warn',
   'lingui/no-single-variables-to-translate': 'warn',
   'lingui/no-trans-inside-trans': 'warn',
-  'lingui/no-expression-in-message': 'warn',
 }
 
 // Assign configs here so we can reference `plugin`


### PR DESCRIPTION
I'd like to open a discussion regarding whether the `no-expression-in-message` rule should be included in the recommended set of rules.
Since lingui@v5 introduced support for [placeholder value comments in the PO files](https://lingui.dev/blog/2024/11/28/announcing-lingui-5.0#print-placeholder-values-for-better-translation-context), the rule seems obsolete. The rule is (for us at least) causing more friction than benefit, as we are forced to destructure objects for no other reason than to satisfy this rule, even though the context makes it clear what the translator should expect.

I ended up creating a PR instead of an issue to make it easier for the maintainers to merge this if they agree with the change, as it took more or less the same amount of effort as writing an issue and waiting for a response.

Let me know what you think and thank you for your work on the project :)