### PR TITLE
feat: add no-macro-inside-macro rule, narrow no-expression-in-message

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Alternatively, add `lingui` to the plugins section, and configure the rules you 
 ✅ - Recommended
 
 - ✅ [no-expression-in-message](docs/rules/no-expression-in-message.md)
+- ✅ [no-macro-inside-macro](docs/rules/no-macro-inside-macro.md)
 - ✅ [no-single-tag-to-translate](docs/rules/no-single-tag-to-translate.md)
 - ✅ [no-single-variables-to-translate](docs/rules/no-single-variables-to-translate.md)
 - ✅ [no-trans-inside-trans](docs/rules/no-trans-inside-trans.md)

--- a/docs/rules/no-expression-in-message.md
+++ b/docs/rules/no-expression-in-message.md
@@ -24,3 +24,7 @@ t`Hello ${userName}` // => 'Hello {userName}'
 msg`Hello ${userName}` // => 'Hello {userName}'
 defineMessage`Hello ${userName}` // => 'Hello {userName}'
 ```
+
+## Scope
+
+This rule flags member expressions (`${obj.prop}`) and non-Lingui function calls (`${func()}`) interpolated into a message macro template. It does **not** flag nested Lingui macros — those are covered by [`no-macro-inside-macro`](./no-macro-inside-macro.md), which produces a targeted diagnostic. Enable both rules to get full coverage.

--- a/docs/rules/no-macro-inside-macro.md
+++ b/docs/rules/no-macro-inside-macro.md
@@ -1,0 +1,96 @@
+# no-macro-inside-macro
+
+Don't nest Lingui translation macros.
+
+Each Lingui translation macro — `` t` ` ``, `` msg` ` ``, `` defineMessage` ` `` and their call forms, plus the components `<Trans>`, `<Plural>`, `<Select>`, `<SelectOrdinal>` — extracts as a **standalone translation unit**. A standalone unit can't be composed into another one: the inner macro becomes an opaque expression at extract time, the outer message falls back to positional placeholders (`{0}`, `{1}`), and the `.po` file ends up with useless (sometimes enormous) placeholder comments.
+
+Concretely, this rule forbids a translation macro inside any of:
+
+- another message macro's template literal or message body (`` t`…${inner}…` ``, `t({ message: `…${inner}…` })`)
+- a `<Plural>` / `<Select>` / `<SelectOrdinal>` branch attribute (excluding `value` / `offset`)
+- a `plural()` / `select()` / `selectOrdinal()` option value (excluding `value` / `offset`)
+
+Two exceptions — both legitimate composition, not nesting:
+
+1. **Choice calls as interpolation**: `` t`${plural(n, { one: '…', other: '…' })}` `` composes the ICU plural into the outer message.
+2. **Descriptor passthrough**: `t(msg`…`)` passes a lazy `MessageDescriptor` as a direct argument for translation.
+
+## Examples
+
+### ❌ Incorrect
+
+```jsx
+// message macro inside message macro
+t`outer ${t`inner`}`
+
+// component macro inside message macro
+t`outer ${<Trans>inner</Trans>}`
+t`outer ${<Plural value={n} one="a" other="b" />}`
+
+// message macro inside choice component branch
+<Plural
+  value={count}
+  one={t`# unread message`}
+  other={t`# unread messages`}
+/>
+
+// component macro inside choice component branch
+<Plural value={n} one={<Trans>a</Trans>} other="b" />
+
+// message macro inside choice call option
+plural(count, {
+  one: t`# unread message`,
+  other: t`# unread messages`,
+})
+
+// component macro inside choice call option
+plural(count, {
+  one: <Trans>a</Trans>,
+  other: <Trans>b</Trans>,
+})
+
+// lazy macro interpolated (not a direct arg) still stringifies as [object Object]
+t`Greeting: ${msg`Hello`}`
+```
+
+### ✅ Correct
+
+```jsx
+// Hoist and interpolate plain values
+const inner = t`inner`
+t`outer ${inner}`
+
+// Branches extract themselves — use plain strings
+<Plural
+  value={count}
+  one="# unread message"
+  other="# unread messages"
+/>
+
+plural(count, {
+  one: '# unread message',
+  other: '# unread messages',
+})
+
+// Choice calls *as interpolation* inside a message macro compose into ICU
+t`You have ${plural(count, { one: '# unread message', other: '# unread messages' })}`
+
+// Descriptor passthrough: lazy macro as a direct argument to t()
+const greeting = msg`Hello`
+t(greeting)
+t(msg`Hello`)
+```
+
+## When Not To Use It
+
+There's no legitimate reason to nest translation macros outside of the two composition patterns above — leave the rule enabled.
+
+## Performance
+
+The rule fires only on nodes named `t` / `msg` / `defineMessage` (tagged-template or call) and JSX elements named `Trans` / `Plural` / `Select` / `SelectOrdinal` — name-filtered at the selector level, so non-matches never enter the handler. For each match the rule walks up the AST to the nearest containing Lingui macro (typically 1–5 hops) or to the program root. Linear in AST depth, no memoization, no quadratic paths. IIFE-bridged nesting (e.g. `<Plural one={(() => t`…`)()}`) is intentionally detected — the walk does not stop at function boundaries.
+
+## Related
+
+- [`no-expression-in-message`](./no-expression-in-message.md) — member expressions and function calls inside message interpolations.
+- [`no-plural-inside-trans`](./no-plural-inside-trans.md) — `<Plural>` inside `<Trans>`.
+- [`no-trans-inside-trans`](./no-trans-inside-trans.md) — `<Trans>` inside `<Trans>`.

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import * as noTransInsideTransRule from './rules/no-trans-inside-trans'
 import * as consistentPluralFormatRule from './rules/consistent-plural-format'
 import * as noPluralInsideTransRule from './rules/no-plural-inside-trans'
 import * as requireExplicitIdRule from './rules/require-explicit-id'
+import * as noMacroInsideMacroRule from './rules/no-macro-inside-macro'
 
 import { ESLint, Linter } from 'eslint'
 import { FlatConfig, RuleModule } from '@typescript-eslint/utils/ts-eslint'
@@ -23,6 +24,7 @@ const rules = {
   [consistentPluralFormatRule.name]: consistentPluralFormatRule.rule,
   [noPluralInsideTransRule.name]: noPluralInsideTransRule.rule,
   [requireExplicitIdRule.name]: requireExplicitIdRule.rule,
+  [noMacroInsideMacroRule.name]: noMacroInsideMacroRule.rule,
 }
 
 type RuleKey = keyof typeof rules
@@ -49,6 +51,7 @@ const recommendedRules: { [K in RuleKey as `lingui/${K}`]?: FlatConfig.RuleLevel
   'lingui/no-single-variables-to-translate': 'warn',
   'lingui/no-trans-inside-trans': 'warn',
   'lingui/no-expression-in-message': 'warn',
+  'lingui/no-macro-inside-macro': 'warn',
 }
 
 // Assign configs here so we can reference `plugin`

--- a/src/rules/no-expression-in-message.ts
+++ b/src/rules/no-expression-in-message.ts
@@ -32,6 +32,34 @@ export const rule = createRule({
   defaultOptions: [],
   create: function (context) {
     const linguiMacroFunctionNames = ['plural', 'select', 'selectOrdinal', 'ph']
+    const nestedMessageMacroNames = ['t', 'msg', 'defineMessage']
+    const nestedComponentMacroNames = ['Trans', 'Plural', 'Select', 'SelectOrdinal']
+
+    // Nested Lingui macros (message macros or JSX component macros) are the
+    // domain of `no-macro-inside-macro`, which reports them with a targeted
+    // message. Skip them here so users get one clear diagnostic instead of two.
+    function isNestedLinguiMacro(expression: TSESTree.Expression): boolean {
+      if (expression.type === TSESTree.AST_NODE_TYPES.TaggedTemplateExpression) {
+        return (
+          expression.tag.type === TSESTree.AST_NODE_TYPES.Identifier &&
+          nestedMessageMacroNames.includes(expression.tag.name)
+        )
+      }
+      if (expression.type === TSESTree.AST_NODE_TYPES.CallExpression) {
+        return (
+          expression.callee.type === TSESTree.AST_NODE_TYPES.Identifier &&
+          nestedMessageMacroNames.includes(expression.callee.name)
+        )
+      }
+      if (expression.type === TSESTree.AST_NODE_TYPES.JSXElement) {
+        const tag = expression.openingElement.name
+        return (
+          tag.type === TSESTree.AST_NODE_TYPES.JSXIdentifier &&
+          nestedComponentMacroNames.includes(tag.name)
+        )
+      }
+      return false
+    }
 
     function checkExpressionsInTplLiteral(node: TSESTree.TemplateLiteral) {
       node.expressions.forEach((expression) => checkExpression(expression))
@@ -79,7 +107,10 @@ export const rule = createRule({
           return
         }
 
-        checkExpressionsInTplLiteral(node)
+        node.expressions.forEach((expression) => {
+          if (isNestedLinguiMacro(expression)) return
+          checkExpression(expression)
+        })
       },
       [`${LinguiTransQuery} JSXExpressionContainer:not([parent.type=JSXAttribute]) > :expression`](
         node: TSESTree.Expression,

--- a/src/rules/no-macro-inside-macro.ts
+++ b/src/rules/no-macro-inside-macro.ts
@@ -1,0 +1,229 @@
+import { TSESTree } from '@typescript-eslint/utils'
+import { createRule } from '../create-rule'
+
+export const name = 'no-macro-inside-macro'
+
+// Eager message macros produce a translated string at the call site.
+// Never safe to nest — the string can't be recomposed into another message.
+const EAGER_MESSAGE_MACRO_NAMES = new Set(['t'])
+
+// Lazy message macros produce a MessageDescriptor value.
+// Safe as a value passed to t() or interpolated into another message, but never safe
+// where a plain string is required (choice branches / option values).
+const LAZY_MESSAGE_MACRO_NAMES = new Set(['msg', 'defineMessage'])
+
+const ALL_MESSAGE_MACRO_NAMES = new Set<string>([
+  ...EAGER_MESSAGE_MACRO_NAMES,
+  ...LAZY_MESSAGE_MACRO_NAMES,
+])
+
+// JSX macro components each extract as their own standalone message unit —
+// never safe to nest inside another macro.
+const JSX_MACRO_COMPONENT_NAMES = new Set(['Trans', 'Plural', 'Select', 'SelectOrdinal'])
+
+const CHOICE_CALL_NAMES = new Set(['plural', 'select', 'selectOrdinal'])
+const CHOICE_COMPONENT_NAMES = new Set(['Plural', 'Select', 'SelectOrdinal'])
+
+// Attributes / option keys on choice macros that are not branch values and may
+// legitimately hold any expression.
+const CHOICE_RESERVED_KEYS = new Set(['value', 'offset'])
+
+type InnerMacro =
+  | { kind: 'eager'; name: string }
+  | { kind: 'lazy'; name: string }
+  | { kind: 'component'; name: string }
+
+type BadContainer =
+  | { kind: 'messageMacro'; outer: string }
+  | { kind: 'choiceComponentBranch'; component: string; attr: string }
+  | { kind: 'choiceCallOption'; call: string; option: string }
+
+function getInnerMacro(node: TSESTree.Node): InnerMacro | null {
+  if (node.type === TSESTree.AST_NODE_TYPES.TaggedTemplateExpression) {
+    if (node.tag.type !== TSESTree.AST_NODE_TYPES.Identifier) return null
+    const name = node.tag.name
+    if (EAGER_MESSAGE_MACRO_NAMES.has(name)) return { kind: 'eager', name }
+    if (LAZY_MESSAGE_MACRO_NAMES.has(name)) return { kind: 'lazy', name }
+    return null
+  }
+  if (node.type === TSESTree.AST_NODE_TYPES.CallExpression) {
+    if (node.callee.type !== TSESTree.AST_NODE_TYPES.Identifier) return null
+    const name = node.callee.name
+    if (EAGER_MESSAGE_MACRO_NAMES.has(name)) return { kind: 'eager', name }
+    if (LAZY_MESSAGE_MACRO_NAMES.has(name)) return { kind: 'lazy', name }
+    return null
+  }
+  if (node.type === TSESTree.AST_NODE_TYPES.JSXElement) {
+    const tag = node.openingElement.name
+    if (tag.type !== TSESTree.AST_NODE_TYPES.JSXIdentifier) return null
+    if (JSX_MACRO_COMPONENT_NAMES.has(tag.name)) return { kind: 'component', name: tag.name }
+    return null
+  }
+  return null
+}
+
+function isMessageMacroNode(node: TSESTree.Node): string | null {
+  if (
+    node.type === TSESTree.AST_NODE_TYPES.TaggedTemplateExpression &&
+    node.tag.type === TSESTree.AST_NODE_TYPES.Identifier &&
+    ALL_MESSAGE_MACRO_NAMES.has(node.tag.name)
+  ) {
+    return node.tag.name
+  }
+  if (
+    node.type === TSESTree.AST_NODE_TYPES.CallExpression &&
+    node.callee.type === TSESTree.AST_NODE_TYPES.Identifier &&
+    ALL_MESSAGE_MACRO_NAMES.has(node.callee.name)
+  ) {
+    return node.callee.name
+  }
+  return null
+}
+
+function getPropertyKeyName(key: TSESTree.Node): string | null {
+  if (key.type === TSESTree.AST_NODE_TYPES.Identifier) return key.name
+  if (
+    key.type === TSESTree.AST_NODE_TYPES.Literal &&
+    (typeof key.value === 'string' || typeof key.value === 'number')
+  ) {
+    return String(key.value)
+  }
+  return null
+}
+
+// Walk up from `node` to the nearest Lingui container in which the inner macro is illegal.
+function findBadContainer(node: TSESTree.Node): BadContainer | null {
+  let current: TSESTree.Node | undefined = node.parent
+  while (current) {
+    const outerMessageMacro = isMessageMacroNode(current)
+    if (outerMessageMacro) {
+      return { kind: 'messageMacro', outer: outerMessageMacro }
+    }
+
+    if (current.type === TSESTree.AST_NODE_TYPES.JSXAttribute) {
+      const opening = current.parent
+      if (
+        opening?.type === TSESTree.AST_NODE_TYPES.JSXOpeningElement &&
+        opening.name.type === TSESTree.AST_NODE_TYPES.JSXIdentifier &&
+        CHOICE_COMPONENT_NAMES.has(opening.name.name) &&
+        current.name.type === TSESTree.AST_NODE_TYPES.JSXIdentifier &&
+        !CHOICE_RESERVED_KEYS.has(current.name.name)
+      ) {
+        return {
+          kind: 'choiceComponentBranch',
+          component: opening.name.name,
+          attr: current.name.name,
+        }
+      }
+    }
+
+    if (current.type === TSESTree.AST_NODE_TYPES.Property) {
+      const obj = current.parent
+      const call = obj?.parent
+      if (
+        obj?.type === TSESTree.AST_NODE_TYPES.ObjectExpression &&
+        call?.type === TSESTree.AST_NODE_TYPES.CallExpression &&
+        call.callee.type === TSESTree.AST_NODE_TYPES.Identifier &&
+        CHOICE_CALL_NAMES.has(call.callee.name) &&
+        call.arguments[1] === obj
+      ) {
+        const keyName = getPropertyKeyName(current.key)
+        if (keyName && !CHOICE_RESERVED_KEYS.has(keyName)) {
+          return {
+            kind: 'choiceCallOption',
+            call: call.callee.name,
+            option: keyName,
+          }
+        }
+      }
+    }
+
+    current = current.parent
+  }
+  return null
+}
+
+// The canonical descriptor-passthrough pattern: `t(msg`...`)` / `t(defineMessage(...))`.
+// A lazy message macro is valid *only* as a direct call argument to another message macro call;
+// anywhere else it's interpolated/stringified as `[object Object]` at runtime.
+function isLazyPassthrough(node: TSESTree.Node, inner: InnerMacro): boolean {
+  if (inner.kind !== 'lazy') return false
+  const parent = node.parent
+  if (parent?.type !== TSESTree.AST_NODE_TYPES.CallExpression) return false
+  if (!parent.arguments.includes(node as TSESTree.CallExpressionArgument)) return false
+  return isMessageMacroNode(parent) !== null
+}
+
+export const rule = createRule({
+  name,
+  meta: {
+    docs: {
+      description:
+        'Disallow nesting Lingui translation macros. Message macros (t, msg, defineMessage) and component macros (Trans, Plural, Select, SelectOrdinal) each extract as a standalone translation unit and cannot be composed through another macro.',
+      recommended: 'error',
+    },
+    messages: {
+      insideMessageMacro:
+        'Do not nest `{{inner}}` inside `{{outer}}`. Translation macros each extract as a standalone unit — use plain text or a variable interpolation instead.',
+      insideChoiceComponentBranch:
+        'Do not use `{{inner}}` inside the `{{attr}}` branch of `<{{component}}>`. The branch is already the extracted string — use a plain string literal.',
+      insideChoiceCallOption:
+        'Do not use `{{inner}}` inside the `{{option}}` option of `{{call}}()`. The option is already the extracted string — use a plain string literal.',
+    },
+    schema: [],
+    type: 'problem' as const,
+  },
+
+  defaultOptions: [],
+  create(context) {
+    function check(node: TSESTree.Node) {
+      const inner = getInnerMacro(node)
+      if (!inner) return
+      if (isLazyPassthrough(node, inner)) return
+      const container = findBadContainer(node)
+      if (!container) return
+
+      switch (container.kind) {
+        case 'messageMacro':
+          context.report({
+            node,
+            messageId: 'insideMessageMacro',
+            data: { inner: inner.name, outer: container.outer },
+          })
+          return
+        case 'choiceComponentBranch':
+          context.report({
+            node,
+            messageId: 'insideChoiceComponentBranch',
+            data: { inner: inner.name, component: container.component, attr: container.attr },
+          })
+          return
+        case 'choiceCallOption':
+          context.report({
+            node,
+            messageId: 'insideChoiceCallOption',
+            data: { inner: inner.name, call: container.call, option: container.option },
+          })
+          return
+      }
+    }
+
+    return {
+      ':matches(TaggedTemplateExpression[tag.name=t], TaggedTemplateExpression[tag.name=msg], TaggedTemplateExpression[tag.name=defineMessage])'(
+        node: TSESTree.TaggedTemplateExpression,
+      ) {
+        check(node)
+      },
+      ':matches(CallExpression[callee.name=t], CallExpression[callee.name=msg], CallExpression[callee.name=defineMessage])'(
+        node: TSESTree.CallExpression,
+      ) {
+        check(node)
+      },
+      ':matches(JSXElement[openingElement.name.name=Trans], JSXElement[openingElement.name.name=Plural], JSXElement[openingElement.name.name=Select], JSXElement[openingElement.name.name=SelectOrdinal])'(
+        node: TSESTree.JSXElement,
+      ) {
+        check(node)
+      },
+    }
+  },
+})

--- a/tests/src/rules/no-expression-in-message.test.ts
+++ b/tests/src/rules/no-expression-in-message.test.ts
@@ -99,6 +99,41 @@ ruleTester.run(name, rule, {
     {
       code: '<Trans>hello {ph({name: obj.prop})}</Trans>',
     },
+    // Nested Lingui macros inside a message macro template are handled by
+    // `no-macro-inside-macro` with a targeted message — this rule must not
+    // also fire on them or users would see duplicate diagnostics.
+    {
+      name: 'Nested t`` in t`` template: deferred to no-macro-inside-macro',
+      code: 't`Hello ${t`world`}`',
+    },
+    {
+      name: 'Nested msg`` in t`` template: deferred to no-macro-inside-macro',
+      code: 't`Hello ${msg`world`}`',
+    },
+    {
+      name: 'Nested defineMessage`` in t`` template: deferred to no-macro-inside-macro',
+      code: 't`Hello ${defineMessage`world`}`',
+    },
+    {
+      name: 'Nested t() call in t`` template: deferred to no-macro-inside-macro',
+      code: 't`Hello ${t({ message: "world" })}`',
+    },
+    {
+      name: 'JSX <Trans/> interpolated in t`` template: deferred to no-macro-inside-macro',
+      code: 't`Hello ${<Trans>world</Trans>}`',
+    },
+    {
+      name: 'JSX <Plural/> interpolated in t`` template: deferred to no-macro-inside-macro',
+      code: 't`Hello ${<Plural value={n} one="a" other="b" />}`',
+    },
+    {
+      name: 'Nested t`` in msg`` template: deferred to no-macro-inside-macro',
+      code: 'msg`Hello ${t`world`}`',
+    },
+    {
+      name: 'Nested t`` in t() message option template: deferred to no-macro-inside-macro',
+      code: 't({ message: `Hello ${t`world`}` })',
+    },
   ],
   invalid: [
     {

--- a/tests/src/rules/no-macro-inside-macro.test.ts
+++ b/tests/src/rules/no-macro-inside-macro.test.ts
@@ -1,0 +1,300 @@
+import { rule, name } from '../../../src/rules/no-macro-inside-macro'
+import { RuleTester } from '@typescript-eslint/rule-tester'
+
+describe('', () => {})
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parserOptions: {
+      ecmaFeatures: {
+        jsx: true,
+      },
+    },
+  },
+})
+
+ruleTester.run(name, rule, {
+  valid: [
+    // ==================== Plain message macros ====================
+    {
+      name: 'allows t`` with identifier interpolation',
+      code: 't`Hello ${name}`',
+    },
+    {
+      name: 'allows msg`` with identifier interpolation',
+      code: 'msg`Hello ${name}`',
+    },
+    {
+      name: 'allows defineMessage`` with identifier interpolation',
+      code: 'defineMessage`Hello ${name}`',
+    },
+    {
+      name: 'allows t() with message option as template literal',
+      code: 't({ message: `Hello ${name}` })',
+    },
+
+    // ==================== Choice calls as template interpolation ====================
+    // plural()/select()/selectOrdinal() inside a message macro template compose
+    // into ICU; they are not nested translation units.
+    {
+      name: 'allows plural() interpolated into t`` template',
+      code: 't`${plural(count, { one: "# book", other: "# books" })}`',
+    },
+    {
+      name: 'allows select() interpolated into t`` template',
+      code: 't`${select(gender, { male: "he", female: "she", other: "they" })}`',
+    },
+    {
+      name: 'allows selectOrdinal() interpolated into t`` template',
+      code: 't`${selectOrdinal(n, { one: "#st", other: "#th" })}`',
+    },
+
+    // ==================== Lazy descriptor passthrough ====================
+    // msg/defineMessage produce MessageDescriptor values; passing them as a
+    // direct argument to t() is the canonical passthrough pattern.
+    {
+      name: 'allows msg`` as direct argument to t()',
+      code: 't(msg`Hello`)',
+    },
+    {
+      name: 'allows defineMessage`` as direct argument to t()',
+      code: 't(defineMessage`Hello`)',
+    },
+    {
+      name: 'allows msg() call form as direct argument to t()',
+      code: 't(msg({ id: "greeting", message: "Hello" }))',
+    },
+
+    // ==================== Plain choice components ====================
+    {
+      name: 'allows <Plural> with plain string branches',
+      code: '<Plural value={count} one="# book" other="# books" />',
+    },
+    {
+      name: 'allows <Select> with plain string branches',
+      code: '<Select value={gender} male="he" female="she" other="they" />',
+    },
+    {
+      name: 'allows <SelectOrdinal> with plain string branches',
+      code: '<SelectOrdinal value={n} one="#st" other="#th" />',
+    },
+
+    // ==================== Plain choice calls ====================
+    {
+      name: 'allows plural() with plain string options',
+      code: 'plural(count, { one: "# book", other: "# books" })',
+    },
+    {
+      name: 'allows select() with plain string options',
+      code: 'select(gender, { male: "he", female: "she", other: "they" })',
+    },
+    {
+      name: 'allows selectOrdinal() with plain string options',
+      code: 'selectOrdinal(n, { one: "#st", other: "#th" })',
+    },
+
+    // ==================== value / offset positions are unrestricted ====================
+    {
+      name: 'allows macro expression in <Plural> value attribute',
+      code: '<Plural value={t`dynamic`.length} one="a" other="b" />',
+    },
+    {
+      name: 'allows any expression in plural() offset option',
+      code: 'plural(count, { offset: someFn(), one: "a", other: "b" })',
+    },
+
+    // ==================== Same name, not a macro ====================
+    {
+      name: 'ignores member-access tagged template (obj.t`...`)',
+      code: 'obj.t`Hello`',
+    },
+    {
+      name: 'ignores member-access plural() call',
+      code: 'obj.plural(n, { one: t`x`, other: t`y` })',
+    },
+    {
+      name: 'ignores local identifier shadowing `t`',
+      code: 'const notMacro = t => t`ok`; notMacro()',
+    },
+
+    // ==================== Top-level component macros ====================
+    {
+      name: 'allows top-level <Trans> with identifier interpolation',
+      code: '<Trans>Hello {userName}</Trans>',
+    },
+    {
+      name: 'allows top-level <Plural>',
+      code: '<Plural value={count} one="# book" other="# books" />',
+    },
+    {
+      name: 'allows top-level <Select>',
+      code: '<Select value={gender} male="he" female="she" other="they" />',
+    },
+    {
+      name: 'allows top-level <SelectOrdinal>',
+      code: '<SelectOrdinal value={n} one="#st" other="#th" />',
+    },
+  ],
+  invalid: [
+    // ==================== Eager message macro inside another message macro ====================
+    {
+      name: 'flags t`` inside t`` template',
+      code: 't`outer ${t`inner`}`',
+      errors: [{ messageId: 'insideMessageMacro', data: { inner: 't', outer: 't' } }],
+    },
+    {
+      name: 'flags t`` inside msg`` template',
+      code: 'msg`outer ${t`inner`}`',
+      errors: [{ messageId: 'insideMessageMacro', data: { inner: 't', outer: 'msg' } }],
+    },
+    {
+      name: 'flags t`` inside defineMessage`` template',
+      code: 'defineMessage`outer ${t`inner`}`',
+      errors: [{ messageId: 'insideMessageMacro', data: { inner: 't', outer: 'defineMessage' } }],
+    },
+    {
+      name: 'flags t`` inside t() message option template',
+      code: 't({ message: `outer ${t`inner`}` })',
+      errors: [{ messageId: 'insideMessageMacro', data: { inner: 't', outer: 't' } }],
+    },
+    {
+      name: 'flags t() call inside t() message option template',
+      code: 't({ message: `outer ${t({ message: "inner" })}` })',
+      errors: [{ messageId: 'insideMessageMacro', data: { inner: 't', outer: 't' } }],
+    },
+    {
+      name: 'reports each nested macro independently',
+      code: 't`a ${t`b`} c ${t`d`}`',
+      errors: [
+        { messageId: 'insideMessageMacro', data: { inner: 't', outer: 't' } },
+        { messageId: 'insideMessageMacro', data: { inner: 't', outer: 't' } },
+      ],
+    },
+
+    // ==================== Lazy message macro interpolated, not passed through ====================
+    // Interpolation stringifies a MessageDescriptor as [object Object] at runtime.
+    {
+      name: 'flags msg`` interpolated into t`` template',
+      code: 't`Greeting: ${msg`Hello`}`',
+      errors: [{ messageId: 'insideMessageMacro', data: { inner: 'msg', outer: 't' } }],
+    },
+    {
+      name: 'flags defineMessage`` interpolated into msg`` template',
+      code: 'msg`Greeting: ${defineMessage`Hello`}`',
+      errors: [{ messageId: 'insideMessageMacro', data: { inner: 'defineMessage', outer: 'msg' } }],
+    },
+    {
+      name: 'flags msg`` as message property (not a direct argument)',
+      code: 't({ message: msg`Hello` })',
+      errors: [{ messageId: 'insideMessageMacro', data: { inner: 'msg', outer: 't' } }],
+    },
+
+    // ==================== Component macro inside a message macro ====================
+    {
+      name: 'flags <Trans> interpolated into t`` template',
+      code: 't`outer ${<Trans>inner</Trans>}`',
+      errors: [{ messageId: 'insideMessageMacro', data: { inner: 'Trans', outer: 't' } }],
+    },
+    {
+      name: 'flags <Plural> interpolated into t`` template',
+      code: 't`outer ${<Plural value={n} one="a" other="b" />}`',
+      errors: [{ messageId: 'insideMessageMacro', data: { inner: 'Plural', outer: 't' } }],
+    },
+    {
+      name: 'flags <Select> interpolated into t`` template',
+      code: 't`outer ${<Select value={g} male="a" other="b" />}`',
+      errors: [{ messageId: 'insideMessageMacro', data: { inner: 'Select', outer: 't' } }],
+    },
+    {
+      name: 'flags <SelectOrdinal> interpolated into t`` template',
+      code: 't`outer ${<SelectOrdinal value={n} one="a" other="b" />}`',
+      errors: [{ messageId: 'insideMessageMacro', data: { inner: 'SelectOrdinal', outer: 't' } }],
+    },
+    {
+      name: 'flags <Trans> interpolated into msg`` template',
+      code: 'msg`outer ${<Trans>inner</Trans>}`',
+      errors: [{ messageId: 'insideMessageMacro', data: { inner: 'Trans', outer: 'msg' } }],
+    },
+    {
+      name: 'flags <Trans> interpolated into t() message option template',
+      code: 't({ message: `outer ${<Trans>inner</Trans>}` })',
+      errors: [{ messageId: 'insideMessageMacro', data: { inner: 'Trans', outer: 't' } }],
+    },
+
+    // ==================== Message macro inside a choice component branch ====================
+    {
+      name: 'flags t`` in <Plural> branches',
+      code: '<Plural value={count} one={t`# unread message`} other={t`# unread messages`} />',
+      errors: [
+        { messageId: 'insideChoiceComponentBranch', data: { inner: 't', component: 'Plural', attr: 'one' } },
+        { messageId: 'insideChoiceComponentBranch', data: { inner: 't', component: 'Plural', attr: 'other' } },
+      ],
+    },
+    {
+      name: 'flags msg`` in <Plural> branches',
+      code: '<Plural value={count} one={msg`# unread message`} other={msg`# unread messages`} />',
+      errors: [
+        { messageId: 'insideChoiceComponentBranch', data: { inner: 'msg', component: 'Plural', attr: 'one' } },
+        { messageId: 'insideChoiceComponentBranch', data: { inner: 'msg', component: 'Plural', attr: 'other' } },
+      ],
+    },
+    {
+      name: 'flags msg`` in <Select> branches',
+      code: '<Select value={gender} male={msg`he`} female={msg`she`} other={msg`they`} />',
+      errors: [
+        { messageId: 'insideChoiceComponentBranch', data: { inner: 'msg', component: 'Select', attr: 'male' } },
+        { messageId: 'insideChoiceComponentBranch', data: { inner: 'msg', component: 'Select', attr: 'female' } },
+        { messageId: 'insideChoiceComponentBranch', data: { inner: 'msg', component: 'Select', attr: 'other' } },
+      ],
+    },
+    {
+      name: 'flags t`` in <SelectOrdinal> branches',
+      code: '<SelectOrdinal value={n} one={t`#st`} other={t`#th`} />',
+      errors: [
+        { messageId: 'insideChoiceComponentBranch', data: { inner: 't', component: 'SelectOrdinal', attr: 'one' } },
+        { messageId: 'insideChoiceComponentBranch', data: { inner: 't', component: 'SelectOrdinal', attr: 'other' } },
+      ],
+    },
+
+    // ==================== Component macro inside a choice component branch ====================
+    {
+      name: 'flags <Trans> in a <Plural> branch',
+      code: '<Plural value={n} one={<Trans>a</Trans>} other="b" />',
+      errors: [{ messageId: 'insideChoiceComponentBranch', data: { inner: 'Trans', component: 'Plural', attr: 'one' } }],
+    },
+    {
+      name: 'flags nested <Plural> in a <Plural> branch',
+      code: '<Plural value={n} one={<Plural value={m} one="x" other="y" />} other="b" />',
+      errors: [{ messageId: 'insideChoiceComponentBranch', data: { inner: 'Plural', component: 'Plural', attr: 'one' } }],
+    },
+
+    // ==================== Message macro inside a choice call option ====================
+    {
+      name: 'flags t`` in plural() options',
+      code: 'plural(count, { one: t`# book`, other: t`# books` })',
+      errors: [
+        { messageId: 'insideChoiceCallOption', data: { inner: 't', call: 'plural', option: 'one' } },
+        { messageId: 'insideChoiceCallOption', data: { inner: 't', call: 'plural', option: 'other' } },
+      ],
+    },
+    {
+      name: 'flags msg`` in select() options',
+      code: 'select(gender, { male: msg`he`, female: msg`she`, other: msg`they` })',
+      errors: [
+        { messageId: 'insideChoiceCallOption', data: { inner: 'msg', call: 'select', option: 'male' } },
+        { messageId: 'insideChoiceCallOption', data: { inner: 'msg', call: 'select', option: 'female' } },
+        { messageId: 'insideChoiceCallOption', data: { inner: 'msg', call: 'select', option: 'other' } },
+      ],
+    },
+
+    // ==================== Component macro inside a choice call option ====================
+    {
+      name: 'flags <Trans> in plural() options',
+      code: 'plural(count, { one: <Trans>a</Trans>, other: <Trans>b</Trans> })',
+      errors: [
+        { messageId: 'insideChoiceCallOption', data: { inner: 'Trans', call: 'plural', option: 'one' } },
+        { messageId: 'insideChoiceCallOption', data: { inner: 'Trans', call: 'plural', option: 'other' } },
+      ],
+    },
+  ],
+})


### PR DESCRIPTION
Closes #90.

Adds a new `no-macro-inside-macro` rule and narrows `no-expression-in-message` to avoid duplicate diagnostics on the overlapping cases.

## Motivation

Lingui's extractor silently produces broken `.po` output when a translation macro is nested inside another — the inner macro becomes an opaque expression, the outer message falls back to positional placeholders (`{0}`, `{1}`), and placeholder comments can balloon with source fragments (see lingui/js-lingui#2260). No existing rule caught all the ways this can happen, and the partial coverage in `no-expression-in-message` was reported with a misleading "Should be ${variable}, not ${object.property}" message.

## New rule: `no-macro-inside-macro`

Forbids translation macros from being nested inside another translation macro. Scope:

- Message macros (`t` / `msg` / `defineMessage`, tagged-template or call form) inside another message macro's template literal or message-option body
- Any translation macro — message or component — inside a `<Plural>` / `<Select>` / `<SelectOrdinal>` branch JSXAttribute (except `value` / `offset`)
- Any translation macro inside a `plural()` / `select()` / `selectOrdinal()` option value (except `value` / `offset`)
- Component macros (`<Trans>` / `<Plural>` / `<Select>` / `<SelectOrdinal>`) interpolated into a message macro template

Two exceptions are legitimate composition, not nesting:

1. **Choice calls as template interpolation.** `` t`${plural(n, { one: '…', other: '…' })}` `` composes the ICU plural into the outer message.
2. **Descriptor passthrough.** ``t(msg`…`)`` passes a lazy `MessageDescriptor` as a direct argument for translation. Allowed only when the lazy macro is a *direct argument* to a message macro call; interpolating it into a template literal still stringifies as `[object Object]` at runtime and is flagged.

Name follows the existing convention (`no-trans-inside-trans`, `no-plural-inside-trans`).

### Files

- `src/rules/no-macro-inside-macro.ts` — rule (229 lines)
- `tests/src/rules/no-macro-inside-macro.test.ts` — 26 valid + 23 invalid cases, all named, grouped by `// ==================== Section ====================` headers matching `no-unlocalized-strings.test.ts` conventions
- `docs/rules/no-macro-inside-macro.md` — user-facing docs with scope, examples, and a performance note
- `src/index.ts` — register rule; add to `recommendedRules` at `'warn'` (matching peer structural rules like `no-trans-inside-trans`)
- `README.md` — rule index entry

## Change: narrow `no-expression-in-message`

The rule's docs describe its purpose as "member or function expressions in templates," but its `checkExpression` fall-through branch was also firing on any other expression type (nested `TaggedTemplateExpression`, `CallExpression`, `JSXElement`) with a misleading generic message. That behaviour duplicated coverage the new rule now owns with a targeted diagnostic.

This PR adds an `isNestedLinguiMacro` helper and skips nested macro interpolations in the message-template handler only. The Trans-children handler is untouched, so `<Trans>Hello {func()}</Trans>` and `<Trans>Hello {obj.prop}</Trans>` continue to fire as before.

No existing test case regresses — all existing invalid cases are `${obj.prop}` / `${func()}` / `{obj.prop}` shaped. Added 8 new valid cases documenting that nested macros in templates are now deferred.

### Clean split of responsibility

| Shape | Rule |
|---|---|
| `` t`${obj.prop}` `` | `no-expression-in-message` |
| `` t`${func()}` `` | `no-expression-in-message` |
| `<Trans>{obj.prop}</Trans>` | `no-expression-in-message` |
| `<Trans>{func()}</Trans>` | `no-expression-in-message` |
| `` t`${t`x`}` `` | `no-macro-inside-macro` |
| `` t`${msg`x`}` `` | `no-macro-inside-macro` |
| `` t`${<Trans/>}` `` | `no-macro-inside-macro` |
| ``<Plural one={t`x`}/>`` | `no-macro-inside-macro` |
| ``plural(n, { one: t`x` })`` | `no-macro-inside-macro` |
| `<Trans>{<Plural/>}</Trans>` | `no-plural-inside-trans` (pre-existing; not touched here) |
| `<Trans>{<Trans/>}</Trans>` | `no-trans-inside-trans` (pre-existing; not touched here) |

### Pre-existing overlap not addressed

`no-expression-in-message`'s Trans-children handler still overlaps with `no-plural-inside-trans` and `no-trans-inside-trans` — all three fire on `<Trans>{<Plural/>}</Trans>` and `<Trans>{<Trans/>}</Trans>`. That's pre-existing and out of scope here; a follow-up could narrow the Trans-children fall-through the same way (skip when the expression is itself a component macro).

## Performance

The new rule fires only on nodes named `t` / `msg` / `defineMessage` or JSX elements named `Trans` / `Plural` / `Select` / `SelectOrdinal` (name-filtered at the selector level). Per match it walks up to the nearest containing Lingui macro — typically 1–5 hops, or to the program root if none is found. Linear in AST depth, no memoization, no quadratic paths. Comparable to the existing descendant-combinator rules (`no-plural-inside-trans`, `no-trans-inside-trans`). IIFE-bridged nesting is intentionally detected (the walk does not stop at function boundaries).

The narrowing in `no-expression-in-message` adds one O(1) name-set check per template interpolation, skipping a `context.report` call when it matches — net-positive on codebases that nest macros.

## Tests

`yarn test` — 361 tests pass across 12 suites (existing 312 + new 49 from `no-macro-inside-macro.test.ts` + 8 new valid cases in `no-expression-in-message.test.ts`). No regressions.
