### PR TITLE
fix(no-single-variables-to-translate): allow top-level calls to plural/select/selectOrdinal

### DIFF
--- a/src/rules/no-single-variables-to-translate.ts
+++ b/src/rules/no-single-variables-to-translate.ts
@@ -69,7 +69,7 @@ export const rule = createRule({
 
         if (
           node.type === TSESTree.AST_NODE_TYPES.TemplateLiteral &&
-          node.expressions.length >= 1 &&
+          node.expressions.length === 1 &&
           node.expressions[0].type === TSESTree.AST_NODE_TYPES.CallExpression &&
           node.expressions[0].callee.type === TSESTree.AST_NODE_TYPES.Identifier &&
           ['plural', 'select', 'selectOrdinal'].includes(node.expressions[0].callee.name)

--- a/src/rules/no-single-variables-to-translate.ts
+++ b/src/rules/no-single-variables-to-translate.ts
@@ -63,14 +63,24 @@ export const rule = createRule({
       [`${LinguiTaggedTemplateExpressionMessageQuery}, ${LinguiCallExpressionMessageQuery}`](
         node: TSESTree.TemplateLiteral | TSESTree.Literal,
       ) {
-        if (!getText(node)) {
-          context.report({
-            node,
-            messageId: 'asFunction',
-          })
+        if (getText(node)) {
+          return
         }
 
-        return
+        if (
+          node.type === TSESTree.AST_NODE_TYPES.TemplateLiteral &&
+          node.expressions.length >= 1 &&
+          node.expressions[0].type === TSESTree.AST_NODE_TYPES.CallExpression &&
+          node.expressions[0].callee.type === TSESTree.AST_NODE_TYPES.Identifier &&
+          ['plural', 'select', 'selectOrdinal'].includes(node.expressions[0].callee.name)
+        ) {
+          return
+        }
+
+        context.report({
+          node,
+          messageId: 'asFunction',
+        })
       },
     }
   },

--- a/tests/src/rules/no-single-variables-to-translate.test.ts
+++ b/tests/src/rules/no-single-variables-to-translate.test.ts
@@ -25,6 +25,24 @@ ruleTester.run(name, rule, {
       code: 't`Hello ${hello}`',
     },
     {
+      code: 't`${plural(count, { one: "# item", other: "# items" })}`',
+    },
+    {
+      code: 't`${select(gender, { male: "he", female: "she", other: "they" })}`',
+    },
+    {
+      code: 't`${selectOrdinal(count, { one: "#st", two: "#nd", few: "#rd", other: "#th" })}`',
+    },
+    {
+      code: 't({ message: `${plural(count, { one: "# item", other: "# items" })}` })',
+    },
+    {
+      code: 't({ message: `${select(gender, { male: "he", female: "she", other: "they" })}` })',
+    },
+    {
+      code: 't({ message: `${selectOrdinal(count, { one: "#st", two: "#nd", few: "#rd", other: "#th" })}` })',
+    },
+    {
       code: 'msg`Hello ${hello}`',
     },
     {
@@ -123,6 +141,11 @@ ruleTester.run(name, rule, {
     },
     {
       code: 't`${hello}`',
+
+      errors: errorsForT,
+    },
+    {
+      code: 't`${hello()}`',
 
       errors: errorsForT,
     },


### PR DESCRIPTION
Fixes https://github.com/lingui/eslint-plugin/issues/126

This PR updates the `no-single-variables-to-translate` logic to explicitly allow syntax like `` msg`${plural(...)}` ``, which seems to be the recommended way to do plural messages with a custom i18n instance (outside of JSX), according to this discussion: https://github.com/lingui/js-lingui/issues/1312#issuecomment-2434484074